### PR TITLE
feat: add empty state component

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,18 @@
+import { LucideIcon } from "lucide-react";
+import { ReactNode } from "react";
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  message: string;
+  action: ReactNode;
+}
+
+export const EmptyState = ({ icon: Icon, message, action }: EmptyStateProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center py-10 text-center">
+      <Icon className="h-8 w-8 text-muted-foreground mb-4" />
+      <p className="text-muted-foreground mb-4">{message}</p>
+      {action}
+    </div>
+  );
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,6 +10,7 @@ import Layout from "@/components/Layout";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { TaskStatus, castAIFlags } from "@/types/database";
+import { EmptyState } from "@/components/EmptyState";
 
 const Dashboard = () => {
   // Fetch KPI data
@@ -195,8 +196,19 @@ const Dashboard = () => {
                 <TableBody>
                   {kpiData?.riskyTasks.length === 0 ? (
                     <TableRow>
-                      <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
-                        No hay tasks en riesgo
+                      <TableCell colSpan={6}>
+                        <EmptyState
+                          icon={CheckCircle}
+                          message="No hay tasks en riesgo"
+                          action={
+                            <Link to="/subjects">
+                              <Button>
+                                <Plus className="mr-2 h-4 w-4" />
+                                Nueva OT
+                              </Button>
+                            </Link>
+                          }
+                        />
                       </TableCell>
                     </TableRow>
                   ) : (

--- a/src/pages/SubjectsList.tsx
+++ b/src/pages/SubjectsList.tsx
@@ -9,13 +9,14 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { CalendarIcon, Search, Filter, Plus, Clock } from "lucide-react";
+import { CalendarIcon, Search, Filter, Plus, Clock, FileText } from "lucide-react";
 import { Link } from "react-router-dom";
 import Layout from "@/components/Layout";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { cn } from "@/lib/utils";
 import { SubjectStatus } from "@/types/database";
+import { EmptyState } from "@/components/EmptyState";
 
 const SubjectsList = () => {
   const [searchTerm, setSearchTerm] = useState("");
@@ -220,8 +221,17 @@ const SubjectsList = () => {
                 <TableBody>
                   {!subjects || subjects.length === 0 ? (
                     <TableRow>
-                      <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
-                        No se encontraron órdenes de trabajo
+                      <TableCell colSpan={6}>
+                        <EmptyState
+                          icon={FileText}
+                          message="No se encontraron órdenes de trabajo"
+                          action={
+                            <Button>
+                              <Plus className="mr-2 h-4 w-4" />
+                              Nueva OT
+                            </Button>
+                          }
+                        />
                       </TableCell>
                     </TableRow>
                   ) : (

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -19,6 +19,7 @@ import { es } from "date-fns/locale";
 import { useToast } from "@/hooks/use-toast";
 import { TaskStatus, RequiredEvidence, castRequiredEvidence } from "@/types/database";
 import { EvidenceUpload } from "@/components/EvidenceUpload";
+import { EmptyState } from "@/components/EmptyState";
 
 const TaskDetail = () => {
   const { id } = useParams<{ id: string }>();
@@ -622,9 +623,15 @@ const TaskDetail = () => {
                 {/* Evidence List */}
                 <div className="space-y-2 mt-4">
                   {evidence.length === 0 ? (
-                    <p className="text-center py-4 text-muted-foreground">
-                      No hay evidencias subidas
-                    </p>
+                    <EmptyState
+                      icon={FileText}
+                      message="No hay evidencias subidas"
+                      action={
+                        <Button onClick={() => document.querySelector('input[type="file"]')?.click()}>
+                          Subir evidencia
+                        </Button>
+                      }
+                    />
                   ) : (
                     evidence.map((item) => (
                       <div key={item.id} className="flex items-center justify-between p-2 border rounded">


### PR DESCRIPTION
## Summary
- add generic `<EmptyState>` component for empty list views
- replace inline empty states on dashboard, subjects list, and task detail

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in supabase functions)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b382c6a8e0832e822bf54ccf421281