### PR TITLE
feat: add landing page and multi-entry build

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Landing page and app deployment
+
+This repository now includes a simple marketing landing page located in `landing/`. The Vite configuration builds both the landing and the main application. Deploy the contents of `dist/landing` to your main domain and serve the app from `/app` or `app.yourdomain.com`.

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bitácora Plus</title>
+    <meta name="description" content="Organiza y registra tus actividades con Bitácora Plus" />
+  </head>
+  <body class="bg-background text-foreground">
+    <main class="flex flex-col items-center justify-center min-h-screen p-4 text-center">
+      <h1 class="text-4xl font-bold mb-4">Bitácora Plus</h1>
+      <p class="mb-6 max-w-xl">
+        La manera más simple de registrar tus actividades y progresos. Mantén el control de tu bitácora desde cualquier lugar.
+      </p>
+      <img src="/placeholder.svg" alt="Captura de la app" class="rounded shadow mb-6 w-64 h-40 object-cover" />
+      <a href="/app" class="px-6 py-3 bg-primary text-primary-foreground rounded">Ir a la app</a>
+    </main>
+    <script type="module" src="/landing/main.ts"></script>
+  </body>
+</html>

--- a/landing/main.ts
+++ b/landing/main.ts
@@ -1,0 +1,3 @@
+import "../src/index.css";
+
+console.log("Landing page loaded");

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,7 @@ export default {
 		"./components/**/*.{ts,tsx}",
 		"./app/**/*.{ts,tsx}",
 		"./src/**/*.{ts,tsx}",
+                "./landing/**/*.{html,ts,tsx}",
 	],
 	prefix: "",
 	theme: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,12 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rollupOptions: {
+      input: {
+        app: path.resolve(__dirname, "index.html"),
+        landing: path.resolve(__dirname, "landing/index.html"),
+      }
+    }
+  },
 }));


### PR DESCRIPTION
## Summary
- add marketing landing folder with basic script and styling
- include landing in Tailwind content and Vite build input
- document how to deploy landing and app separately

## Testing
- `npm run lint` (fails: Unexpected any etc.)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b37b2b04b8832eae8d40339ff42df6