### PR TITLE
feat: add supabase function helper

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,15 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export async function invokeFunction(path: string, init?: RequestInit) {
+  const { error, response } = await supabase.functions.invoke(path, {
+    method: init?.method,
+    headers: init?.headers as Record<string, string> | undefined,
+    body: init?.body as any,
+  });
+
+  if (error || !response) {
+    throw error || new Error("Failed to invoke function");
+  }
+
+  return response;
+}

--- a/src/pages/SubjectDetail.tsx
+++ b/src/pages/SubjectDetail.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { invokeFunction } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -134,7 +135,7 @@ const SubjectDetail = () => {
       // For now, export the first task. Later we can implement multi-task export
       const firstTaskId = taskIds[0];
       
-      const response = await fetch(`https://eeprxrlmcbtywuuwnuex.supabase.co/functions/v1/export-task-pdf/${firstTaskId}.pdf`, {
+      const response = await invokeFunction(`export-task-pdf/${firstTaskId}.pdf`, {
         method: 'GET',
         headers: {
           'Authorization': `Bearer ${session.access_token}`,

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { invokeFunction } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -266,7 +267,7 @@ const TaskDetail = () => {
         return;
       }
 
-      const response = await fetch(`https://eeprxrlmcbtywuuwnuex.supabase.co/functions/v1/export-task-pdf/${id}.pdf`, {
+      const response = await invokeFunction(`export-task-pdf/${id}.pdf`, {
         method: 'GET',
         headers: {
           'Authorization': `Bearer ${session.access_token}`,


### PR DESCRIPTION
## Summary
- add reusable helper to invoke Supabase edge functions with existing client
- switch SubjectDetail and TaskDetail PDF export to use new helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, require import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b37b452e4c832eaa093af2c28220ab