### PR TITLE
feat: add explicit domain types and typed Supabase queries

### DIFF
--- a/src/pages/SubjectDetail.tsx
+++ b/src/pages/SubjectDetail.tsx
@@ -13,17 +13,18 @@ import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { TaskStatus, SubjectStatus, castAIFlags } from "@/types/database";
 import { useToast } from "@/hooks/use-toast";
+import { Subject, Task, Evidence, LogEntry } from "@/types/entities";
 
 const SubjectDetail = () => {
   const { id } = useParams<{ id: string }>();
   const { toast } = useToast();
 
   // Fetch subject details
-  const { data: subject, isLoading } = useQuery({
+  const { data: subject, isLoading } = useQuery<Subject>({
     queryKey: ['subject', id],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from('subjects')
+        .from<Subject>('subjects')
         .select(`
           *,
           tasks (
@@ -48,17 +49,17 @@ const SubjectDetail = () => {
         .single();
       
       if (error) throw error;
-      return data;
+      return data as Subject;
     },
     enabled: !!id
   });
 
   // Fetch evidence for this subject
-  const { data: evidence } = useQuery({
+  const { data: evidence } = useQuery<Evidence[]>({
     queryKey: ['subject-evidence', id],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from('evidence')
+        .from<Evidence>('evidence')
         .select(`
           id,
           filename,
@@ -71,7 +72,7 @@ const SubjectDetail = () => {
             title
           )
         `)
-        .in('task_id', subject?.tasks?.map(t => t.id) || []);
+        .in('task_id', subject?.tasks?.map((t: Task) => t.id) || []);
       
       if (error) throw error;
       return data;
@@ -95,7 +96,7 @@ const SubjectDetail = () => {
     return <Badge variant={config.variant}>{config.label}</Badge>;
   };
 
-  const getComplianceChips = (task: any) => {
+  const getComplianceChips = (task: Task) => {
     const flags = castAIFlags(task.ai_flags);
     const chips = [];
     
@@ -258,7 +259,7 @@ const SubjectDetail = () => {
                   ) : (
                     subject.log_entries
                       .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-                      .map((log) => (
+                      .map((log: LogEntry) => (
                         <div key={log.id} className="flex items-start space-x-4 border-l-2 border-muted pl-4 pb-4">
                           <div className="min-w-0 flex-1">
                             <div className="flex items-center justify-between">
@@ -308,7 +309,7 @@ const SubjectDetail = () => {
                         </TableCell>
                       </TableRow>
                     ) : (
-                      subject.tasks.map((task) => (
+                      subject.tasks.map((task: Task) => (
                         <TableRow key={task.id}>
                           <TableCell>
                             <Link to={`/tasks/${task.id}`} className="font-medium hover:underline">
@@ -416,14 +417,14 @@ const SubjectDetail = () => {
                   
                   <div className="text-center p-4 border rounded-lg">
                     <div className="text-2xl font-bold text-green-600">
-                      {subject.tasks?.filter(t => t.status === 'completed').length || 0}
+                      {subject.tasks?.filter((t: Task) => t.status === 'completed').length || 0}
                     </div>
                     <p className="text-sm text-muted-foreground">Completadas</p>
                   </div>
                   
                   <div className="text-center p-4 border rounded-lg">
                     <div className="text-2xl font-bold text-yellow-600">
-                      {subject.tasks?.filter(t => t.status !== 'completed').length || 0}
+                      {subject.tasks?.filter((t: Task) => t.status !== 'completed').length || 0}
                     </div>
                     <p className="text-sm text-muted-foreground">Pendientes</p>
                   </div>

--- a/src/pages/SubjectsList.tsx
+++ b/src/pages/SubjectsList.tsx
@@ -16,6 +16,7 @@ import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { cn } from "@/lib/utils";
 import { SubjectStatus } from "@/types/database";
+import { Subject, Task } from "@/types/entities";
 
 const SubjectsList = () => {
   const [searchTerm, setSearchTerm] = useState("");
@@ -24,11 +25,11 @@ const SubjectsList = () => {
   const [dateTo, setDateTo] = useState<Date>();
 
   // Fetch subjects with filters
-  const { data: subjects, isLoading } = useQuery({
+  const { data: subjects, isLoading } = useQuery<Subject[]>({
     queryKey: ['subjects', searchTerm, statusFilter, dateFrom, dateTo],
     queryFn: async () => {
       let query = supabase
-        .from('subjects')
+        .from<Subject>('subjects')
         .select(`
           id,
           title,
@@ -63,7 +64,7 @@ const SubjectsList = () => {
 
       const { data, error } = await query;
       if (error) throw error;
-      return data;
+      return data as Subject[];
     }
   });
 
@@ -79,11 +80,11 @@ const SubjectsList = () => {
     return <Badge variant={config.variant}>{config.label}</Badge>;
   };
 
-  const getTasksStats = (tasks: any[]) => {
+  const getTasksStats = (tasks: Task[]) => {
     const total = tasks.length;
-    const completed = tasks.filter(t => t.status === 'completed').length;
+    const completed = tasks.filter((t: Task) => t.status === 'completed').length;
     const pending = total - completed;
-    
+
     return { total, completed, pending };
   };
 

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -19,6 +19,7 @@ import { es } from "date-fns/locale";
 import { useToast } from "@/hooks/use-toast";
 import { TaskStatus, RequiredEvidence, castRequiredEvidence } from "@/types/database";
 import { EvidenceUpload } from "@/components/EvidenceUpload";
+import { Task, LogEntry } from "@/types/entities";
 
 const TaskDetail = () => {
   const { id } = useParams<{ id: string }>();
@@ -26,14 +27,14 @@ const TaskDetail = () => {
   const queryClient = useQueryClient();
   
   const [isEditing, setIsEditing] = useState(false);
-  const [formData, setFormData] = useState<any>({});
+  const [formData, setFormData] = useState<Partial<Task> & { due_date?: Date | null }>({});
 
   // Fetch task details
-  const { data: task, isLoading } = useQuery({
+  const { data: task, isLoading } = useQuery<Task>({
     queryKey: ['task', id],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from('tasks')
+        .from<Task>('tasks')
         .select(`
           *,
           subjects (
@@ -65,7 +66,7 @@ const TaskDetail = () => {
         .single();
       
       if (error) throw error;
-      
+
       // Initialize form data when task loads
       setFormData({
         title: data.title,
@@ -74,17 +75,17 @@ const TaskDetail = () => {
         assigned_to: data.assigned_to,
         required_evidence: data.required_evidence || {}
       });
-      
-      return data;
+
+      return data as Task;
     },
     enabled: !!id
   });
 
   // Update task mutation
-  const updateTaskMutation = useMutation({
-    mutationFn: async (updateData: any) => {
+  const updateTaskMutation = useMutation<void, Error, Partial<Task>>({
+    mutationFn: async (updateData: Partial<Task>) => {
       const { error } = await supabase
-        .from('tasks')
+        .from<Task>('tasks')
         .update(updateData)
         .eq('id', id);
       
@@ -118,8 +119,8 @@ const TaskDetail = () => {
 
       // Update task status
       const { error: taskError } = await supabase
-        .from('tasks')
-        .update({ 
+        .from<Task>('tasks')
+        .update({
           status: 'completed' as TaskStatus,
           completed_at: new Date().toISOString()
         })
@@ -129,7 +130,7 @@ const TaskDetail = () => {
 
       // Create log entry for status change
       const { error: logError } = await supabase
-        .from('log_entries')
+        .from<LogEntry>('log_entries')
         .insert({
           tenant_id: task?.tenant_id,
           subject_id: task?.subject_id,
@@ -162,7 +163,7 @@ const TaskDetail = () => {
   });
 
   const handleSave = () => {
-    const updateData: any = {
+    const updateData: Partial<Task> = {
       title: formData.title,
       description: formData.description,
       assigned_to: formData.assigned_to,

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -1,0 +1,71 @@
+import { TaskStatus, SubjectStatus, RequiredEvidence, ChecklistResult, EvidenceKind, LogMetadata, ChecklistItem, EvidenceMetadata } from "./database";
+
+export interface ChecklistTemplate {
+  id: string;
+  name: string;
+  items: ChecklistItem[];
+}
+
+export interface ChecklistRun {
+  id: string;
+  task_id: string;
+  template_id: string;
+  created_at?: string | null;
+  created_by?: string | null;
+  completed_at?: string | null;
+  result?: ChecklistResult | null;
+  checklist_templates?: ChecklistTemplate;
+}
+
+export interface Evidence {
+  id: string;
+  filename: string;
+  file_path: string;
+  kind: EvidenceKind;
+  latitude?: number | null;
+  longitude?: number | null;
+  created_at?: string | null;
+  metadata?: EvidenceMetadata;
+}
+
+export interface Task {
+  id: string;
+  subject_id: string;
+  tenant_id: string;
+  title: string;
+  description?: string | null;
+  status: TaskStatus;
+  due_date?: string | null;
+  completed_at?: string | null;
+  assigned_to?: string | null;
+  required_evidence: RequiredEvidence;
+  ai_risk?: number | null;
+  ai_flags?: string[] | null;
+  checklist_runs?: ChecklistRun[];
+  evidence?: Evidence[];
+  subjects?: Pick<Subject, 'id' | 'title' | 'status'>;
+}
+
+export interface LogEntry {
+  id: string;
+  event_type: string;
+  message: string;
+  created_at: string;
+  created_by?: string | null;
+  metadata?: LogMetadata | null;
+}
+
+export interface Subject {
+  id: string;
+  title: string;
+  description?: string | null;
+  status: SubjectStatus;
+  due_date?: string | null;
+  closed_at?: string | null;
+  created_at?: string | null;
+  ai_health?: number | null;
+  ai_top_issues?: any;
+  tasks?: Task[];
+  log_entries?: LogEntry[];
+}
+


### PR DESCRIPTION
## Summary
- add domain interfaces for tasks, subjects, evidence, checklist runs and logs
- use new types in task and subject pages including form state and mutations
- type Supabase queries with generics for consistent return types

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any, no-require-imports)


------
https://chatgpt.com/codex/tasks/task_e_68b37b490b00832e967dc4808e9ec833