### PR TITLE
feat: enforce file upload size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## File upload limit
+
+Evidence uploads are limited to a maximum file size of 10&nbsp;MB per file.

--- a/src/components/EvidenceUpload.tsx
+++ b/src/components/EvidenceUpload.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { useDropzone } from "react-dropzone";
+import { useDropzone, FileRejection } from "react-dropzone";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -173,12 +173,26 @@ export const EvidenceUpload = ({ taskId, tenantId, subjectId, onUploadComplete, 
     setUploadingFiles(prev => prev.filter(uf => uf.file !== file));
   };
 
+  const onDropRejected = useCallback((fileRejections: FileRejection[]) => {
+    fileRejections.forEach(rejection => {
+      if (rejection.errors.some(e => e.code === 'file-too-large')) {
+        toast({
+          title: "Archivo demasiado grande",
+          description: `"${rejection.file.name}" excede el tamaño máximo de 10 MB.`,
+          variant: "destructive",
+        });
+      }
+    });
+  }, [toast]);
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
+    onDropRejected,
     accept: {
       'image/*': ['.jpg', '.jpeg', '.png', '.gif'],
       'application/pdf': ['.pdf']
     },
+    maxSize: 10 * 1024 * 1024,
     disabled
   });
 
@@ -203,6 +217,9 @@ export const EvidenceUpload = ({ taskId, tenantId, subjectId, onUploadComplete, 
           </p>
           <p className="text-xs text-muted-foreground mb-2">
             Formatos permitidos: JPG, PNG, GIF, PDF
+          </p>
+          <p className="text-xs text-muted-foreground mb-2">
+            Tamaño máximo por archivo: 10 MB
           </p>
           <Button variant="outline" type="button">
             Seleccionar Archivos


### PR DESCRIPTION
## Summary
- limit evidence uploads to 10 MB with `react-dropzone`
- show error when files exceed the allowed size
- document upload limit in UI and README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 67 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b37b56160c832e931c40007530c6f4