### PR TITLE
Add skeleton loaders for subjects and tasks

### DIFF
--- a/src/components/ui/SubjectListSkeleton.tsx
+++ b/src/components/ui/SubjectListSkeleton.tsx
@@ -1,0 +1,34 @@
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function SubjectListSkeleton() {
+  const rows = Array.from({ length: 5 });
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead><Skeleton className="h-4 w-24" /></TableHead>
+          <TableHead><Skeleton className="h-4 w-16" /></TableHead>
+          <TableHead><Skeleton className="h-4 w-20" /></TableHead>
+          <TableHead><Skeleton className="h-4 w-20" /></TableHead>
+          <TableHead><Skeleton className="h-4 w-20" /></TableHead>
+          <TableHead className="text-right"><Skeleton className="h-4 w-24 ml-auto" /></TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((_, i) => (
+          <TableRow key={i}>
+            <TableCell><Skeleton className="h-4 w-40" /></TableCell>
+            <TableCell><Skeleton className="h-4 w-24" /></TableCell>
+            <TableCell><Skeleton className="h-4 w-24" /></TableCell>
+            <TableCell><Skeleton className="h-4 w-24" /></TableCell>
+            <TableCell><Skeleton className="h-4 w-24" /></TableCell>
+            <TableCell className="text-right"><Skeleton className="h-4 w-16 ml-auto" /></TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+export default SubjectListSkeleton;

--- a/src/components/ui/TaskDetailSkeleton.tsx
+++ b/src/components/ui/TaskDetailSkeleton.tsx
@@ -1,0 +1,40 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function TaskDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+        <Skeleton className="h-10 w-32" />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle><Skeleton className="h-5 w-40" /></CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle><Skeleton className="h-5 w-40" /></CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default TaskDetailSkeleton;

--- a/src/pages/SubjectsList.tsx
+++ b/src/pages/SubjectsList.tsx
@@ -9,7 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { CalendarIcon, Search, Filter, Plus, Clock } from "lucide-react";
+import { CalendarIcon, Search, Filter, Plus } from "lucide-react";
+import SubjectListSkeleton from "@/components/ui/SubjectListSkeleton";
 import { Link } from "react-router-dom";
 import Layout from "@/components/Layout";
 import { format } from "date-fns";
@@ -201,10 +202,7 @@ const SubjectsList = () => {
         <Card>
           <CardContent className="p-0">
             {isLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <Clock className="mr-2 h-4 w-4 animate-spin" />
-                Cargando OTs...
-              </div>
+              <SubjectListSkeleton />
             ) : (
               <Table>
                 <TableHeader>

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -12,7 +12,8 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
-import { CalendarIcon, Clock, Upload, FileText, Download, Lock, CheckCircle, AlertTriangle, MapPin, Signature, FileDown } from "lucide-react";
+import { CalendarIcon, Upload, FileText, Download, Lock, CheckCircle, AlertTriangle, MapPin, Signature, FileDown } from "lucide-react";
+import TaskDetailSkeleton from "@/components/ui/TaskDetailSkeleton";
 import Layout from "@/components/Layout";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
@@ -305,10 +306,7 @@ const TaskDetail = () => {
   if (isLoading) {
     return (
       <Layout>
-        <div className="flex items-center justify-center py-8">
-          <Clock className="mr-2 h-4 w-4 animate-spin" />
-          Cargando detalles de la task...
-        </div>
+        <TaskDetailSkeleton />
       </Layout>
     );
   }


### PR DESCRIPTION
## Summary
- add SubjectListSkeleton and TaskDetailSkeleton components
- replace loading spinners with skeletons on subjects list and task detail pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b37c923570832e9af8bdfcc6e2bc00