### PR TITLE
Add EmptyState component for empty subject tables

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+import { TableRow, TableCell } from "@/components/ui/table";
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  button: ReactNode;
+}
+
+const EmptyState = ({ title, description, button }: EmptyStateProps) => (
+  <TableRow>
+    <TableCell colSpan={6} className="py-8">
+      <div className="flex flex-col items-center justify-center text-center space-y-3">
+        <div>
+          <h3 className="text-lg font-medium">{title}</h3>
+          <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+        {button}
+      </div>
+    </TableCell>
+  </TableRow>
+);
+
+export default EmptyState;

--- a/src/pages/SubjectsList.tsx
+++ b/src/pages/SubjectsList.tsx
@@ -12,6 +12,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { CalendarIcon, Search, Filter, Plus, Clock } from "lucide-react";
 import { Link } from "react-router-dom";
 import Layout from "@/components/Layout";
+import EmptyState from "@/components/EmptyState";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { cn } from "@/lib/utils";
@@ -103,10 +104,12 @@ const SubjectsList = () => {
             <h1 className="text-3xl font-bold">Órdenes de Trabajo</h1>
             <p className="text-muted-foreground">Gestión de proyectos y OTs</p>
           </div>
-          <Button>
-            <Plus className="mr-2 h-4 w-4" />
-            Nueva OT
-          </Button>
+          <Link to="/subjects/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              Nueva OT
+            </Button>
+          </Link>
         </div>
 
         {/* Filters */}
@@ -219,11 +222,18 @@ const SubjectsList = () => {
                 </TableHeader>
                 <TableBody>
                   {!subjects || subjects.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
-                        No se encontraron órdenes de trabajo
-                      </TableCell>
-                    </TableRow>
+                    <EmptyState
+                      title="No se encontraron órdenes de trabajo"
+                      description="Crea una nueva OT para comenzar."
+                      button={
+                        <Link to="/subjects/new">
+                          <Button>
+                            <Plus className="mr-2 h-4 w-4" />
+                            Nueva OT
+                          </Button>
+                        </Link>
+                      }
+                    />
                   ) : (
                     subjects.map((subject) => {
                       const tasksStats = getTasksStats(subject.tasks || []);


### PR DESCRIPTION
## Summary
- add reusable `EmptyState` component to display message and action button
- show `EmptyState` when no subjects are found and link new OT actions to creation route

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any and require import errors)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b37c98d8a0832eaa1854f36ddf6385