### PR TITLE
feat: add sitemap generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "build:sitemap": "node scripts/generate-sitemap.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,5 @@ Allow: /
 
 User-agent: *
 Allow: /
+
+Sitemap: https://<tu-dominio>/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://<tu-dominio>/</loc></url>
+  <url><loc>https://<tu-dominio>/dashboard</loc></url>
+  <url><loc>https://<tu-dominio>/subjects</loc></url>
+</urlset>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,25 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const appFile = path.join('src', 'App.tsx');
+const sitemapFile = path.join('public', 'sitemap.xml');
+
+const content = await fs.readFile(appFile, 'utf8');
+const routeRegex = /<Route\s+path="([^"]+)"/g;
+const routes = [];
+let match;
+while ((match = routeRegex.exec(content)) !== null) {
+  const route = match[1];
+  if (route.includes(':') || route === '*') continue;
+  routes.push(route);
+}
+
+const domain = 'https://<tu-dominio>';
+const urls = routes.map((r) => `${domain}${r}`);
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+  urls.map((u) => `  <url><loc>${u}</loc></url>`).join('\n') +
+  `\n</urlset>\n`;
+
+await fs.writeFile(sitemapFile, sitemap);
+console.log(`Generated sitemap with ${routes.length} routes.`);


### PR DESCRIPTION
## Summary
- generate sitemap from App routes with new script
- expose sitemap via robots.txt and npm script

## Testing
- `npm run build:sitemap`
- `npx eslint scripts/generate-sitemap.mjs`
- `npm run lint` *(fails: unexpected any, etc.)*
- `npm test` *(fails: missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b37ca41628832eaa6f5b54cacaddc3