### PR TITLE
feat: add page metadata with custom helmet

### DIFF
--- a/src/components/Helmet.tsx
+++ b/src/components/Helmet.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+interface HelmetProps {
+  title: string;
+  description: string;
+}
+
+export function Helmet({ title, description }: HelmetProps) {
+  useEffect(() => {
+    document.title = title;
+
+    let meta = document.querySelector<HTMLMetaElement>("meta[name='description']");
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.name = "description";
+      document.head.appendChild(meta);
+    }
+    meta.content = description;
+  }, [title, description]);
+
+  return null;
+}
+
+export default Helmet;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,6 +10,7 @@ import Layout from "@/components/Layout";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { TaskStatus, castAIFlags } from "@/types/database";
+import { Helmet } from "@/components/Helmet";
 
 const Dashboard = () => {
   // Fetch KPI data
@@ -91,6 +92,7 @@ const Dashboard = () => {
 
   return (
     <Layout>
+      <Helmet title="Dashboard - Bitácora" description="Resumen operativo y KPIs de cumplimiento" />
       <div className="space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,37 +4,41 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { LayoutDashboard, FileText, CheckSquare } from "lucide-react";
+import { Helmet } from "@/components/Helmet";
 
 const Index = () => {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
-      <div className="max-w-md mx-auto text-center space-y-8">
-        <div className="flex justify-center">
-          <CheckSquare className="h-16 w-16 text-primary" />
+    <>
+      <Helmet title="Inicio - Bitácora" description="Página inicial del sistema Bitácora" />
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="max-w-md mx-auto text-center space-y-8">
+          <div className="flex justify-center">
+            <CheckSquare className="h-16 w-16 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-4xl font-bold mb-4">Bitácora</h1>
+            <p className="text-xl text-muted-foreground">Sistema de Gestión Operativa</p>
+          </div>
+
+          <Card>
+            <CardContent className="p-6 space-y-4">
+              <Link to="/dashboard">
+                <Button className="w-full" size="lg">
+                  <LayoutDashboard className="mr-2 h-4 w-4" />
+                  Ir al Dashboard
+                </Button>
+              </Link>
+              <Link to="/subjects">
+                <Button variant="outline" className="w-full" size="lg">
+                  <FileText className="mr-2 h-4 w-4" />
+                  Ver Órdenes de Trabajo
+                </Button>
+              </Link>
+            </CardContent>
+          </Card>
         </div>
-        <div>
-          <h1 className="text-4xl font-bold mb-4">Bitácora</h1>
-          <p className="text-xl text-muted-foreground">Sistema de Gestión Operativa</p>
-        </div>
-        
-        <Card>
-          <CardContent className="p-6 space-y-4">
-            <Link to="/dashboard">
-              <Button className="w-full" size="lg">
-                <LayoutDashboard className="mr-2 h-4 w-4" />
-                Ir al Dashboard
-              </Button>
-            </Link>
-            <Link to="/subjects">
-              <Button variant="outline" className="w-full" size="lg">
-                <FileText className="mr-2 h-4 w-4" />
-                Ver Órdenes de Trabajo
-              </Button>
-            </Link>
-          </CardContent>
-        </Card>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { Helmet } from "@/components/Helmet";
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,15 +13,18 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
+    <>
+      <Helmet title="404 - Página no encontrada" description="La página solicitada no existe en Bitácora" />
+      <div className="min-h-screen flex items-center justify-center bg-gray-100">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold mb-4">404</h1>
+          <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+          <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+            Return to Home
+          </a>
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/SubjectDetail.tsx
+++ b/src/pages/SubjectDetail.tsx
@@ -13,6 +13,7 @@ import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { TaskStatus, SubjectStatus, castAIFlags } from "@/types/database";
 import { useToast } from "@/hooks/use-toast";
+import { Helmet } from "@/components/Helmet";
 
 const SubjectDetail = () => {
   const { id } = useParams<{ id: string }>();
@@ -52,6 +53,9 @@ const SubjectDetail = () => {
     },
     enabled: !!id
   });
+
+  const pageTitle = subject ? `${subject.title} - Bitácora` : "Detalle OT - Bitácora";
+  const pageDescription = subject?.description || "Información detallada de la orden de trabajo";
 
   // Fetch evidence for this subject
   const { data: evidence } = useQuery({
@@ -173,6 +177,7 @@ const SubjectDetail = () => {
   if (isLoading) {
     return (
       <Layout>
+        <Helmet title="Cargando OT - Bitácora" description="Cargando detalles de la orden de trabajo" />
         <div className="flex items-center justify-center py-8">
           <Clock className="mr-2 h-4 w-4 animate-spin" />
           Cargando detalles de la OT...
@@ -184,6 +189,7 @@ const SubjectDetail = () => {
   if (!subject) {
     return (
       <Layout>
+        <Helmet title="OT no encontrada - Bitácora" description="No se encontró la orden de trabajo solicitada" />
         <div className="text-center py-8">
           <p className="text-muted-foreground">OT no encontrada</p>
         </div>
@@ -193,6 +199,7 @@ const SubjectDetail = () => {
 
   return (
     <Layout>
+      <Helmet title={pageTitle} description={pageDescription} />
       <div className="space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">

--- a/src/pages/SubjectsList.tsx
+++ b/src/pages/SubjectsList.tsx
@@ -16,6 +16,7 @@ import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { cn } from "@/lib/utils";
 import { SubjectStatus } from "@/types/database";
+import { Helmet } from "@/components/Helmet";
 
 const SubjectsList = () => {
   const [searchTerm, setSearchTerm] = useState("");
@@ -96,6 +97,7 @@ const SubjectsList = () => {
 
   return (
     <Layout>
+      <Helmet title="Órdenes de Trabajo - Bitácora" description="Listado de órdenes de trabajo" />
       <div className="space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -19,6 +19,7 @@ import { es } from "date-fns/locale";
 import { useToast } from "@/hooks/use-toast";
 import { TaskStatus, RequiredEvidence, castRequiredEvidence } from "@/types/database";
 import { EvidenceUpload } from "@/components/EvidenceUpload";
+import { Helmet } from "@/components/Helmet";
 
 const TaskDetail = () => {
   const { id } = useParams<{ id: string }>();
@@ -79,6 +80,9 @@ const TaskDetail = () => {
     },
     enabled: !!id
   });
+
+  const pageTitle = task ? `${task.title} - Bitácora` : "Detalle de Task - Bitácora";
+  const pageDescription = task?.description || "Información detallada de la task";
 
   // Update task mutation
   const updateTaskMutation = useMutation({
@@ -305,6 +309,7 @@ const TaskDetail = () => {
   if (isLoading) {
     return (
       <Layout>
+        <Helmet title="Cargando task - Bitácora" description="Cargando detalles de la task" />
         <div className="flex items-center justify-center py-8">
           <Clock className="mr-2 h-4 w-4 animate-spin" />
           Cargando detalles de la task...
@@ -316,6 +321,7 @@ const TaskDetail = () => {
   if (!task) {
     return (
       <Layout>
+        <Helmet title="Task no encontrada - Bitácora" description="No se encontró la task solicitada" />
         <div className="text-center py-8">
           <p className="text-muted-foreground">Task no encontrada</p>
         </div>
@@ -331,6 +337,7 @@ const TaskDetail = () => {
 
   return (
     <Layout>
+      <Helmet title={pageTitle} description={pageDescription} />
       <div className="space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- add lightweight Helmet component to manage document title and meta description
- apply page-specific titles and descriptions across all pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 75 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b37ca840a8832ea1a148c2ca50cd90