### PR TITLE
feat: add realtime task notifications

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import NotificationsPanel from "@/components/NotificationsPanel";
 import { 
   LayoutDashboard, 
   FileText, 
@@ -101,6 +102,7 @@ const Layout = ({ children }: LayoutProps) => {
 
       {/* Main Content */}
       <main className="container mx-auto px-4 py-8">
+        <NotificationsPanel />
         {children}
       </main>
 

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -1,0 +1,21 @@
+import { Card } from "@/components/ui/card";
+import { useNotifications } from "@/hooks/useNotifications";
+
+const NotificationsPanel = () => {
+  const { notifications } = useNotifications();
+
+  if (notifications.length === 0) return null;
+
+  return (
+    <Card className="mb-4 p-4">
+      <h2 className="mb-2 text-sm font-semibold">Notificaciones</h2>
+      <ul className="space-y-1 text-sm">
+        {notifications.map((n) => (
+          <li key={n.id}>{n.message}</li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+export default NotificationsPanel;

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+
+interface Notification {
+  id: string;
+  message: string;
+  createdAt: Date;
+}
+
+export function useNotifications() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    const channel = supabase
+      .channel("tasks-notifications")
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "tasks" },
+        (payload) => {
+          const task = payload.new as { id: string; status?: string; due_date?: string };
+          setNotifications((prev) => [
+            {
+              id: `${task.id}-${payload.commit_timestamp}`,
+              message: `Tarea ${task.id} creada`,
+              createdAt: new Date(),
+            },
+            ...prev,
+          ]);
+        }
+      )
+      .on(
+        "postgres_changes",
+        { event: "UPDATE", schema: "public", table: "tasks" },
+        (payload) => {
+          const oldTask = payload.old as { status?: string; due_date?: string; id: string };
+          const task = payload.new as { id: string; status?: string; due_date?: string };
+          const changes: string[] = [];
+          if (task.status !== oldTask.status) {
+            changes.push(`estado: ${oldTask.status ?? ""} → ${task.status ?? ""}`);
+          }
+          if (task.due_date !== oldTask.due_date) {
+            changes.push(`fecha límite: ${oldTask.due_date ?? ""} → ${task.due_date ?? ""}`);
+          }
+          if (changes.length > 0) {
+            setNotifications((prev) => [
+              {
+                id: `${task.id}-${payload.commit_timestamp}`,
+                message: `Tarea ${task.id} actualizada (${changes.join(", ")})`,
+                createdAt: new Date(),
+              },
+              ...prev,
+            ]);
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, []);
+
+  return { notifications };
+}
+
+export type { Notification };


### PR DESCRIPTION
## Summary
- add useNotifications hook that listens to Supabase Realtime changes on tasks
- display NotificationsPanel in main layout
- show notifications for task insertions and updates to status or due date

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and forbidden require in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b37d74fd7c832ebae4242fb9567e72