### PR TITLE
feat: add service worker and offline request queue

### DIFF
--- a/src/lib/offlineQueue.ts
+++ b/src/lib/offlineQueue.ts
@@ -1,0 +1,75 @@
+export interface QueuedRequest {
+  id?: number;
+  url: string;
+  method: string;
+  body?: string;
+  headers?: Record<string, string>;
+}
+
+const DB_NAME = 'offline-queue';
+const STORE_NAME = 'requests';
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function queueRequest(data: QueuedRequest): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  tx.objectStore(STORE_NAME).add(data);
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function processQueue(): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  const getAllReq = store.getAll();
+  const requests: QueuedRequest[] = await new Promise((resolve, reject) => {
+    getAllReq.onsuccess = () => resolve(getAllReq.result);
+    getAllReq.onerror = () => reject(getAllReq.error);
+  });
+
+  for (const req of requests) {
+    try {
+      await fetch(req.url, {
+        method: req.method,
+        headers: req.headers,
+        body: req.body,
+      });
+      if (req.id !== undefined) {
+        store.delete(req.id);
+      }
+    } catch {
+      // if one request fails, keep it in queue and stop processing
+      break;
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function sendOrQueue(url: string, options: RequestInit): Promise<Response | void> {
+  if (navigator.onLine) {
+    return fetch(url, options);
+  }
+  await queueRequest({
+    url,
+    method: options.method || 'GET',
+    body: options.body as string | undefined,
+    headers: options.headers as Record<string, string> | undefined,
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,21 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { processQueue } from './lib/offlineQueue'
 
-createRoot(document.getElementById("root")!).render(<App />);
+const container = document.getElementById('root')!
+createRoot(container).render(<App />)
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js')
+  })
+
+  window.addEventListener('online', () => {
+    processQueue()
+  })
+}
+
+if (navigator.onLine) {
+  processQueue()
+}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,35 @@
+/// <reference lib="webworker" />
+
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
+
+declare const self: ServiceWorkerGlobalScope;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const { precaching, routing, strategies, core } = (self as any).workbox || {};
+
+// Ensure service worker takes control immediately
+self.addEventListener('install', () => self.skipWaiting());
+if (core?.clientsClaim) {
+  core.clientsClaim();
+}
+
+// Precache assets (self.__WB_MANIFEST will be replaced at build time if available)
+try {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  precaching?.precacheAndRoute((self as any).__WB_MANIFEST || []);
+} catch {
+  // no manifest, ignore
+}
+
+// Cache static resources
+if (routing && strategies) {
+  routing.registerRoute(
+    ({ request }) => ['style', 'script', 'worker', 'image', 'font'].includes(request.destination),
+    new strategies.StaleWhileRevalidate()
+  );
+
+  // Cache API requests for /tasks and /evidence
+  routing.registerRoute(
+    ({ url }) => url.pathname.startsWith('/tasks') || url.pathname.startsWith('/evidence'),
+    new strategies.NetworkFirst()
+  );
+}


### PR DESCRIPTION
## Summary
- cache static assets and /tasks,/evidence requests via Workbox
- register service worker and sync queued requests when connection restores
- add IndexedDB-backed offline queue for network requests

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any... etc.)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b37d779dfc832eaf25cba3690c29f9