### PR TITLE
feat: add tasks map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,8 @@
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "react": "^18.3.1",
+        "leaflet": "^1.9.4",
+        "react-leaflet": "^4.3.3",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.3.8",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.3.3",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.3.8",

--- a/src/components/TasksMap.tsx
+++ b/src/components/TasksMap.tsx
@@ -1,0 +1,86 @@
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { Link } from 'react-router-dom';
+import { useMemo } from 'react';
+
+// Fix default icon paths so markers display correctly in Vite
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: new URL('leaflet/dist/images/marker-icon-2x.png', import.meta.url).toString(),
+  iconUrl: new URL('leaflet/dist/images/marker-icon.png', import.meta.url).toString(),
+  shadowUrl: new URL('leaflet/dist/images/marker-shadow.png', import.meta.url).toString(),
+});
+
+interface MarkerItem {
+  id: string;
+  title: string;
+  lat: number;
+  lon: number;
+  type: 'task' | 'subject';
+}
+
+const TasksMap = () => {
+  const { data } = useQuery({
+    queryKey: ['tasks-map'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('tasks')
+        .select('id, title, latitude, longitude, subject_id, subjects(id, title, latitude, longitude)');
+      if (error) throw error;
+      return data as any[];
+    }
+  });
+
+  const markers: MarkerItem[] = useMemo(() => {
+    if (!data) return [];
+    const items: MarkerItem[] = [];
+    for (const task of data) {
+      const lat = task?.latitude ?? task?.subjects?.latitude;
+      const lon = task?.longitude ?? task?.subjects?.longitude;
+      if (typeof lat === 'number' && typeof lon === 'number') {
+        const fromTask = task?.latitude && task?.longitude;
+        items.push({
+          id: fromTask ? task.id : task.subject_id,
+          title: fromTask ? task.title : task.subjects?.title || 'Sin título',
+          lat,
+          lon,
+          type: fromTask ? 'task' : 'subject',
+        });
+      }
+    }
+    return items;
+  }, [data]);
+
+  const center: [number, number] = markers.length
+    ? [markers[0].lat, markers[0].lon]
+    : [0, 0];
+
+  return (
+    <div className="h-[500px] w-full">
+      <MapContainer center={center} zoom={markers.length ? 13 : 2} className="h-full w-full">
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        {markers.map(item => (
+          <Marker key={`${item.type}-${item.id}`} position={[item.lat, item.lon]}>
+            <Popup>
+              <Link
+                to={item.type === 'task' ? `/tasks/${item.id}` : `/subjects/${item.id}`}
+                className="text-blue-500 underline"
+              >
+                {item.title}
+              </Link>
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+    </div>
+  );
+};
+
+export default TasksMap;
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,12 +4,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Calendar, AlertTriangle, CheckCircle, Clock, Plus } from "lucide-react";
 import { Link } from "react-router-dom";
 import Layout from "@/components/Layout";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
-import { TaskStatus, castAIFlags } from "@/types/database";
+import { TaskStatus } from "@/types/database";
+import TasksMap from "@/components/TasksMap";
 
 const Dashboard = () => {
   // Fetch KPI data
@@ -106,137 +108,150 @@ const Dashboard = () => {
           </Link>
         </div>
 
-        {/* KPI Cards */}
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">On-time %</CardTitle>
-              <CheckCircle className="h-4 w-4 text-green-600" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {kpiLoading ? '-' : `${kpiData?.onTimePercentage || 0}%`}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Tareas completadas a tiempo
-              </p>
-            </CardContent>
-          </Card>
+        <Tabs defaultValue="overview" className="space-y-4">
+          <TabsList>
+            <TabsTrigger value="overview">Resumen</TabsTrigger>
+            <TabsTrigger value="map">Mapa</TabsTrigger>
+          </TabsList>
 
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Compliance-ok %</CardTitle>
-              <CheckCircle className="h-4 w-4 text-blue-600" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {kpiLoading ? '-' : `${kpiData?.compliancePercentage || 0}%`}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Cumplimiento general
-              </p>
-            </CardContent>
-          </Card>
+          <TabsContent value="overview" className="space-y-6">
+            {/* KPI Cards */}
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">On-time %</CardTitle>
+                  <CheckCircle className="h-4 w-4 text-green-600" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">
+                    {kpiLoading ? '-' : `${kpiData?.onTimePercentage || 0}%`}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Tareas completadas a tiempo
+                  </p>
+                </CardContent>
+              </Card>
 
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">SLAs Hoy</CardTitle>
-              <Calendar className="h-4 w-4 text-yellow-600" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {kpiLoading ? '-' : kpiData?.duesToday || 0}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Vencen hoy
-              </p>
-            </CardContent>
-          </Card>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Compliance-ok %</CardTitle>
+                  <CheckCircle className="h-4 w-4 text-blue-600" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">
+                    {kpiLoading ? '-' : `${kpiData?.compliancePercentage || 0}%`}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Cumplimiento general
+                  </p>
+                </CardContent>
+              </Card>
 
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">En Riesgo</CardTitle>
-              <AlertTriangle className="h-4 w-4 text-destructive" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {kpiLoading ? '-' : kpiData?.atRisk || 0}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Tareas críticas
-              </p>
-            </CardContent>
-          </Card>
-        </div>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">SLAs Hoy</CardTitle>
+                  <Calendar className="h-4 w-4 text-yellow-600" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">
+                    {kpiLoading ? '-' : kpiData?.duesToday || 0}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Vencen hoy
+                  </p>
+                </CardContent>
+              </Card>
 
-        {/* Tasks en Riesgo Table */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Tasks en Riesgo</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {kpiLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <Clock className="mr-2 h-4 w-4 animate-spin" />
-                Cargando...
-              </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Task</TableHead>
-                    <TableHead>OT</TableHead>
-                    <TableHead>Estado</TableHead>
-                    <TableHead>Vencimiento</TableHead>
-                    <TableHead>Nivel de Riesgo</TableHead>
-                    <TableHead className="text-right">Acciones</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {kpiData?.riskyTasks.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
-                        No hay tasks en riesgo
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    kpiData?.riskyTasks.map((task) => {
-                      const risk = getRiskLevel(task);
-                      return (
-                        <TableRow key={task.id}>
-                          <TableCell className="font-medium">
-                            <Link to={`/tasks/${task.id}`} className="hover:underline">
-                              {task.title}
-                            </Link>
-                          </TableCell>
-                          <TableCell>
-                            <Link to={`/subjects/${task.subjects.id}`} className="hover:underline text-primary">
-                              {task.subjects.title}
-                            </Link>
-                          </TableCell>
-                          <TableCell>{getStatusBadge(task.status)}</TableCell>
-                          <TableCell>
-                            {task.due_date ? format(new Date(task.due_date), 'dd/MM/yyyy', { locale: es }) : 'Sin fecha'}
-                          </TableCell>
-                          <TableCell>
-                            <span className={risk.color}>{risk.level}</span>
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <Link to={`/tasks/${task.id}`}>
-                              <Button variant="outline" size="sm">
-                                Ver Detalle
-                              </Button>
-                            </Link>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">En Riesgo</CardTitle>
+                  <AlertTriangle className="h-4 w-4 text-destructive" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">
+                    {kpiLoading ? '-' : kpiData?.atRisk || 0}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Tareas críticas
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Tasks en Riesgo Table */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Tasks en Riesgo</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {kpiLoading ? (
+                  <div className="flex items-center justify-center py-8">
+                    <Clock className="mr-2 h-4 w-4 animate-spin" />
+                    Cargando...
+                  </div>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Task</TableHead>
+                        <TableHead>OT</TableHead>
+                        <TableHead>Estado</TableHead>
+                        <TableHead>Vencimiento</TableHead>
+                        <TableHead>Nivel de Riesgo</TableHead>
+                        <TableHead className="text-right">Acciones</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {kpiData?.riskyTasks.length === 0 ? (
+                        <TableRow>
+                          <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
+                            No hay tasks en riesgo
                           </TableCell>
                         </TableRow>
-                      );
-                    })
-                  )}
-                </TableBody>
-              </Table>
-            )}
-          </CardContent>
-        </Card>
+                      ) : (
+                        kpiData?.riskyTasks.map((task) => {
+                          const risk = getRiskLevel(task);
+                          return (
+                            <TableRow key={task.id}>
+                              <TableCell className="font-medium">
+                                <Link to={`/tasks/${task.id}`} className="hover:underline">
+                                  {task.title}
+                                </Link>
+                              </TableCell>
+                              <TableCell>
+                                <Link to={`/subjects/${task.subjects.id}`} className="hover:underline text-primary">
+                                  {task.subjects.title}
+                                </Link>
+                              </TableCell>
+                              <TableCell>{getStatusBadge(task.status)}</TableCell>
+                              <TableCell>
+                                {task.due_date ? format(new Date(task.due_date), 'dd/MM/yyyy', { locale: es }) : 'Sin fecha'}
+                              </TableCell>
+                              <TableCell>
+                                <span className={risk.color}>{risk.level}</span>
+                              </TableCell>
+                              <TableCell className="text-right">
+                                <Link to={`/tasks/${task.id}`}>
+                                  <Button variant="outline" size="sm">
+                                    Ver Detalle
+                                  </Button>
+                                </Link>
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })
+                      )}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="map">
+            <TasksMap />
+          </TabsContent>
+        </Tabs>
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- add Leaflet and react-leaflet dependencies
- implement TasksMap component to render geolocated pins linking to details
- integrate TasksMap in Dashboard page under new "Mapa" tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b37d7a6614832e90955b637f6471e8