### PR TITLE
feat: add task comments

### DIFF
--- a/src/components/TaskComments.tsx
+++ b/src/components/TaskComments.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+
+interface TaskCommentsProps {
+  taskId: string;
+}
+
+interface TaskComment {
+  id?: string;
+  user_id: string;
+  message: string;
+  created_at: string;
+}
+
+export const TaskComments = ({ taskId }: TaskCommentsProps) => {
+  const [message, setMessage] = useState("");
+  const queryClient = useQueryClient();
+
+  const { data: comments, isLoading } = useQuery<TaskComment[]>({
+    queryKey: ['task_comments', taskId],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('task_comments')
+        .select('id, user_id, message, created_at')
+        .eq('task_id', taskId)
+        .order('created_at', { ascending: true });
+      if (error) throw error;
+      return data as TaskComment[];
+    }
+  });
+
+  const addComment = useMutation({
+    mutationFn: async (text: string) => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Usuario no autenticado');
+      const { error } = await supabase
+        .from('task_comments')
+        .insert({
+          task_id: taskId,
+          user_id: user.id,
+          message: text
+        });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      setMessage("");
+      queryClient.invalidateQueries({ queryKey: ['task_comments', taskId] });
+    }
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!message.trim()) return;
+    addComment.mutate(message.trim());
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Comentarios</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Cargando...</p>
+          ) : comments && comments.length > 0 ? (
+            comments.map((comment) => (
+              <div key={comment.id ?? comment.created_at} className="border-b pb-2">
+                <p className="text-sm">{comment.message}</p>
+                <p className="text-xs text-muted-foreground">
+                  {format(new Date(comment.created_at), 'dd/MM/yyyy HH:mm', { locale: es })}
+                </p>
+              </div>
+            ))
+          ) : (
+            <p className="text-sm text-muted-foreground">No hay comentarios</p>
+          )}
+        </div>
+        <form onSubmit={handleSubmit} className="flex space-x-2 mt-4">
+          <Input
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Escribe un comentario"
+          />
+          <Button type="submit" disabled={addComment.isPending || !message.trim()}>Enviar</Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TaskComments;

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -19,6 +19,7 @@ import { es } from "date-fns/locale";
 import { useToast } from "@/hooks/use-toast";
 import { TaskStatus, RequiredEvidence, castRequiredEvidence } from "@/types/database";
 import { EvidenceUpload } from "@/components/EvidenceUpload";
+import { TaskComments } from "@/components/TaskComments";
 
 const TaskDetail = () => {
   const { id } = useParams<{ id: string }>();
@@ -650,9 +651,11 @@ const TaskDetail = () => {
                 </div>
               </CardContent>
             </Card>
-          </div>
+      </div>
         </div>
       </div>
+
+      <TaskComments taskId={id!} />
     </Layout>
   );
 };

--- a/supabase/migrations/20250831000000_601ca872-0a12-4b47-8cc3-a4ecd5503e49.sql
+++ b/supabase/migrations/20250831000000_601ca872-0a12-4b47-8cc3-a4ecd5503e49.sql
@@ -1,0 +1,31 @@
+CREATE TABLE public.task_comments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  task_id UUID NOT NULL REFERENCES public.tasks(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  message TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+ALTER TABLE public.task_comments ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX ON public.task_comments (task_id, created_at);
+
+-- Allow users to read comments for tasks in their tenant
+CREATE POLICY task_comments_select ON public.task_comments
+FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM public.tasks t
+    WHERE t.id = task_comments.task_id
+      AND t.tenant_id = public.current_tenant_id()
+  )
+);
+
+-- Allow users to insert comments for tasks in their tenant
+CREATE POLICY task_comments_insert ON public.task_comments
+FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.tasks t
+    WHERE t.id = task_comments.task_id
+      AND t.tenant_id = public.current_tenant_id()
+  ) AND user_id = auth.uid()
+);


### PR DESCRIPTION
## Summary
- add task comments table and row-level security
- allow users to view and post task comments
- integrate comments in task detail page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Unexpected any...)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b37d7b7bd4832e8cb786179ef2da10