### PR TITLE
Add signature capture for task evidence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.3.8",
+        "react-signature-canvas": "^1.0.7",
         "react-hook-form": "^7.61.1",
         "react-resizable-panels": "^2.1.9",
         "react-router-dom": "^6.30.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.3.8",
+    "react-signature-canvas": "^1.0.7",
     "react-hook-form": "^7.61.1",
     "react-resizable-panels": "^2.1.9",
     "react-router-dom": "^6.30.1",

--- a/src/components/SignaturePad.tsx
+++ b/src/components/SignaturePad.tsx
@@ -1,0 +1,87 @@
+import { useRef } from "react";
+import SignatureCanvas from "react-signature-canvas";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+
+interface SignaturePadProps {
+  taskId: string;
+  tenantId: string;
+  subjectId: string;
+  onSave: () => void;
+  disabled?: boolean;
+}
+
+export const SignaturePad = ({ taskId, tenantId, subjectId, onSave, disabled }: SignaturePadProps) => {
+  const sigCanvas = useRef<SignatureCanvas | null>(null);
+  const { toast } = useToast();
+
+  const clear = () => {
+    sigCanvas.current?.clear();
+  };
+
+  const save = async () => {
+    if (!sigCanvas.current || sigCanvas.current.isEmpty()) {
+      toast({
+        title: "No hay firma",
+        description: "Por favor firme antes de guardar",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      const canvas = sigCanvas.current.getTrimmedCanvas();
+      const dataUrl = canvas.toDataURL("image/png");
+      const blob = await (await fetch(dataUrl)).blob();
+      const filename = `signature-${Date.now()}.png`;
+      const filePath = `${tenantId}/${subjectId}/${taskId}/${filename}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from("bitacora")
+        .upload(filePath, blob);
+      if (uploadError) throw uploadError;
+
+      const { error: dbError } = await supabase.from("evidence").insert({
+        tenant_id: tenantId,
+        task_id: taskId,
+        filename,
+        file_path: filePath,
+        kind: "signature",
+      });
+      if (dbError) throw dbError;
+
+      toast({
+        title: "Firma guardada",
+        description: "La firma se guardó correctamente",
+      });
+
+      onSave();
+      clear();
+    } catch (error: any) {
+      toast({
+        title: "Error al guardar",
+        description: error.message,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <SignatureCanvas
+        ref={sigCanvas}
+        penColor="black"
+        canvasProps={{ className: "border w-full h-48 bg-white" }}
+      />
+      <div className="flex space-x-2">
+        <Button variant="outline" type="button" onClick={clear} disabled={disabled}>
+          Limpiar
+        </Button>
+        <Button type="button" onClick={save} disabled={disabled}>
+          Guardar Firma
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -19,6 +19,7 @@ import { es } from "date-fns/locale";
 import { useToast } from "@/hooks/use-toast";
 import { TaskStatus, RequiredEvidence, castRequiredEvidence } from "@/types/database";
 import { EvidenceUpload } from "@/components/EvidenceUpload";
+import { SignaturePad } from "@/components/SignaturePad";
 
 const TaskDetail = () => {
   const { id } = useParams<{ id: string }>();
@@ -215,9 +216,9 @@ const TaskDetail = () => {
     
     // 3. Check signature requirement  
     if (required.signature_required) {
-      const hasSignature = evidence.some(e => e.kind === 'pdf');
+      const hasSignature = evidence.some(e => e.kind === 'signature');
       if (!hasSignature) {
-        errors.push('Se requiere firma o documento firmado (PDF)');
+        errors.push('Se requiere firma');
       }
     }
     
@@ -327,7 +328,7 @@ const TaskDetail = () => {
   const required = castRequiredEvidence(task.required_evidence);
   const photoCount = evidence.filter(e => e.kind === 'photo').length;
   const hasGeotag = evidence.some(e => e.latitude && e.longitude);
-  const hasSignature = evidence.some(e => e.kind === 'pdf');
+  const hasSignature = evidence.some(e => e.kind === 'signature');
 
   return (
     <Layout>
@@ -619,6 +620,18 @@ const TaskDetail = () => {
                   disabled={task.status === 'completed'}
                 />
 
+                {required.signature_required && (
+                  <div className="mt-4">
+                    <SignaturePad
+                      taskId={id!}
+                      tenantId={task.tenant_id}
+                      subjectId={task.subject_id}
+                      onSave={() => queryClient.invalidateQueries({ queryKey: ['task', id] })}
+                      disabled={task.status === 'completed'}
+                    />
+                  </div>
+                )}
+
                 {/* Evidence List */}
                 <div className="space-y-2 mt-4">
                   {evidence.length === 0 ? (
@@ -631,6 +644,8 @@ const TaskDetail = () => {
                         <div className="flex items-center space-x-2">
                           {item.kind === 'photo' ? (
                             <FileText className="h-4 w-4" />
+                          ) : item.kind === 'signature' ? (
+                            <Signature className="h-4 w-4" />
                           ) : (
                             <FileText className="h-4 w-4" />
                           )}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -46,7 +46,7 @@ export interface LogMetadata {
 export type TaskStatus = "pending" | "in_progress" | "completed" | "blocked";
 export type SubjectStatus = "draft" | "active" | "closed" | "cancelled";
 export type UserRole = "owner" | "editor" | "viewer";
-export type EvidenceKind = "photo" | "pdf";
+export type EvidenceKind = "photo" | "pdf" | "signature";
 
 // Helper functions for type casting
 export const castRequiredEvidence = (data: any): RequiredEvidence => {


### PR DESCRIPTION
## Summary
- add `react-signature-canvas` dependency
- create `SignaturePad` component to capture and upload signatures
- show signature pad in task detail and validate presence before closing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any; require import warning)*

------
https://chatgpt.com/codex/tasks/task_e_68b37d7eb954832e80a95a3734b11a50