### PR TITLE
feat: interpret AI flags in dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -25,6 +25,7 @@ const Dashboard = () => {
           due_date,
           completed_at,
           ai_risk,
+          ai_flags,
           subjects (
             id,
             title,
@@ -50,9 +51,13 @@ const Dashboard = () => {
         t.status !== 'completed'
       ).length || 0;
       
-      const atRisk = tasks?.filter(t => 
-        t.status !== 'completed' && 
-        ((t.due_date && new Date(t.due_date) < today) || (t.ai_risk && t.ai_risk > 70))
+      const atRisk = tasks?.filter(t =>
+        t.status !== 'completed' &&
+        (
+          (t.due_date && new Date(t.due_date) < today) ||
+          (t.ai_risk && t.ai_risk > 70) ||
+          castAIFlags(t.ai_flags).length > 0
+        )
       ).length || 0;
 
       return {
@@ -60,9 +65,13 @@ const Dashboard = () => {
         compliancePercentage: total > 0 ? Math.round((completed / total) * 100) : 0,
         duesToday,
         atRisk,
-        riskyTasks: tasks?.filter(t => 
-          t.status !== 'completed' && 
-          ((t.due_date && new Date(t.due_date) < today) || (t.ai_risk && t.ai_risk > 70))
+        riskyTasks: tasks?.filter(t =>
+          t.status !== 'completed' &&
+          (
+            (t.due_date && new Date(t.due_date) < today) ||
+            (t.ai_risk && t.ai_risk > 70) ||
+            castAIFlags(t.ai_flags).length > 0
+          )
         ).slice(0, 10) || []
       };
     }
@@ -83,9 +92,21 @@ const Dashboard = () => {
   const getRiskLevel = (task: any) => {
     const isOverdue = task.due_date && new Date(task.due_date) < new Date();
     const hasHighRisk = task.ai_risk && task.ai_risk > 70;
-    
+    const flags = castAIFlags(task.ai_flags);
+
     if (isOverdue) return { level: 'Vencida', color: 'text-destructive' };
     if (hasHighRisk) return { level: 'Alto Riesgo', color: 'text-orange-500' };
+    if (flags.length > 0) {
+      const flagLabels: Record<string, string> = {
+        missing_geotag: 'Sin Geotag',
+        insufficient_photos: 'Fotos Insuf.',
+        duplicate_photo: 'Foto Duplicada',
+        missing_signature: 'Sin Firma',
+        checklist_incomplete: 'Checklist Inc.'
+      };
+      const firstFlag = flags[0];
+      return { level: flagLabels[firstFlag] || 'Observación', color: 'text-orange-500' };
+    }
     return { level: 'En Riesgo', color: 'text-yellow-600' };
   };
 


### PR DESCRIPTION
## Summary
- include `ai_flags` when fetching tasks
- factor AI flags into risk counts and risk level helper

## Testing
- `npm run lint` *(fails: Unexpected any in supabase/functions and tailwind.config.ts)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b37fd3618c832eb17aeba25520c7b4