### PR TITLE
Add Task interface and use in dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -9,7 +9,7 @@ import { Link } from "react-router-dom";
 import Layout from "@/components/Layout";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
-import { TaskStatus, castAIFlags } from "@/types/database";
+import { TaskStatus, Task } from "@/types/database";
 
 const Dashboard = () => {
   // Fetch KPI data
@@ -80,7 +80,7 @@ const Dashboard = () => {
     return <Badge variant={config.variant}>{config.label}</Badge>;
   };
 
-  const getRiskLevel = (task: any) => {
+  const getRiskLevel = (task: Task) => {
     const isOverdue = task.due_date && new Date(task.due_date) < new Date();
     const hasHighRisk = task.ai_risk && task.ai_risk > 70;
     
@@ -200,7 +200,7 @@ const Dashboard = () => {
                       </TableCell>
                     </TableRow>
                   ) : (
-                    kpiData?.riskyTasks.map((task) => {
+                    kpiData?.riskyTasks.map((task: Task) => {
                       const risk = getRiskLevel(task);
                       return (
                         <TableRow key={task.id}>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -32,14 +32,14 @@ export interface EvidenceMetadata {
   size?: number;
   mimeType?: string;
   checksum?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface LogMetadata {
-  previousValue?: any;
-  newValue?: any;
+  previousValue?: unknown;
+  newValue?: unknown;
   userId?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 // Task status types
@@ -48,23 +48,37 @@ export type SubjectStatus = "draft" | "active" | "closed" | "cancelled";
 export type UserRole = "owner" | "editor" | "viewer";
 export type EvidenceKind = "photo" | "pdf";
 
+export interface Task {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  due_date?: string | null;
+  completed_at?: string | null;
+  ai_risk?: number | null;
+  subjects: {
+    id: string;
+    title: string;
+    status: SubjectStatus;
+  };
+}
+
 // Helper functions for type casting
-export const castRequiredEvidence = (data: any): RequiredEvidence => {
+export const castRequiredEvidence = (data: unknown): RequiredEvidence => {
   if (!data || typeof data !== 'object') return {};
   return data as RequiredEvidence;
 };
 
-export const castChecklistResult = (data: any): ChecklistResult => {
+export const castChecklistResult = (data: unknown): ChecklistResult => {
   if (!data || typeof data !== 'object') return {};
   return data as ChecklistResult;
 };
 
-export const castAIFlags = (data: any): string[] => {
+export const castAIFlags = (data: unknown): string[] => {
   if (!Array.isArray(data)) return [];
   return data as string[];
 };
 
-export const castLogMetadata = (data: any): LogMetadata => {
+export const castLogMetadata = (data: unknown): LogMetadata => {
   if (!data || typeof data !== 'object') return {};
   return data as LogMetadata;
 };


### PR DESCRIPTION
## Summary
- define Task interface in database types
- improve casting helpers with `unknown`
- use Task type in Dashboard risk calculations

## Testing
- `npx eslint src/pages/Dashboard.tsx src/types/database.ts`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b37fd66bd8832eb3c0bd50a1d7eccb