### PR TITLE
Handle missing subject links in dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -209,11 +209,15 @@ const Dashboard = () => {
                               {task.title}
                             </Link>
                           </TableCell>
-                          <TableCell>
-                            <Link to={`/subjects/${task.subjects.id}`} className="hover:underline text-primary">
-                              {task.subjects.title}
-                            </Link>
-                          </TableCell>
+                            <TableCell>
+                              {task.subjects ? (
+                                <Link to={`/subjects/${task.subjects.id}`} className="hover:underline text-primary">
+                                  {task.subjects.title}
+                                </Link>
+                              ) : (
+                                "Sin OT"
+                              )}
+                            </TableCell>
                           <TableCell>{getStatusBadge(task.status)}</TableCell>
                           <TableCell>
                             {task.due_date ? format(new Date(task.due_date), 'dd/MM/yyyy', { locale: es }) : 'Sin fecha'}


### PR DESCRIPTION
## Summary
- Avoid errors when risky tasks lack a subject by checking `task.subjects`
- Display "Sin OT" instead of a subject link when none is present

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any errors and require import)*

------
https://chatgpt.com/codex/tasks/task_e_68b37fda35f4832ea2f74c3ebe255098