### PR TITLE
feat: color code task status badges

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -70,14 +70,22 @@ const Dashboard = () => {
 
   const getStatusBadge = (status: TaskStatus | string) => {
     const variants = {
-      'pending': { variant: 'secondary' as const, label: 'Pendiente' },
-      'in_progress': { variant: 'default' as const, label: 'En Progreso' },
-      'completed': { variant: 'default' as const, label: 'Completada' },
-      'blocked': { variant: 'destructive' as const, label: 'Bloqueada' }
+      pending: { variant: 'secondary' as const, label: 'Pendiente' },
+      in_progress: {
+        variant: 'outline' as const,
+        label: 'En Progreso',
+        className: 'bg-yellow-500 text-white hover:bg-yellow-600'
+      },
+      completed: {
+        variant: 'outline' as const,
+        label: 'Completada',
+        className: 'bg-green-500 text-white hover:bg-green-600'
+      },
+      blocked: { variant: 'destructive' as const, label: 'Bloqueada' }
     };
-    
+
     const config = variants[status as keyof typeof variants] || variants.pending;
-    return <Badge variant={config.variant}>{config.label}</Badge>;
+    return <Badge variant={config.variant} className={config.className}>{config.label}</Badge>;
   };
 
   const getRiskLevel = (task: any) => {


### PR DESCRIPTION
## Summary
- differentiate in-progress and completed statuses with unique badge colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b37fdd7b7c832e9f8f005ec7f3e039