### PR TITLE
feat: add incidents management pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import Dashboard from "./pages/Dashboard";
 import SubjectsList from "./pages/SubjectsList";
 import SubjectDetail from "./pages/SubjectDetail";
 import TaskDetail from "./pages/TaskDetail";
+import IncidentsList from "./pages/IncidentsList";
+import IncidentDetail from "./pages/IncidentDetail";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -24,6 +26,8 @@ const App = () => (
           <Route path="/subjects" element={<SubjectsList />} />
           <Route path="/subjects/:id" element={<SubjectDetail />} />
           <Route path="/tasks/:id" element={<TaskDetail />} />
+          <Route path="/incidents" element={<IncidentsList />} />
+          <Route path="/incidents/:id" element={<IncidentDetail />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -578,6 +578,44 @@ export type Database = {
           },
         ]
       }
+      incidents: {
+        Row: {
+          id: string
+          subject_id: string
+          category: string
+          description: string | null
+          status: string
+          created_at: string | null
+          resolved_at: string | null
+        }
+        Insert: {
+          id?: string
+          subject_id: string
+          category: string
+          description?: string | null
+          status?: string
+          created_at?: string | null
+          resolved_at?: string | null
+        }
+        Update: {
+          id?: string
+          subject_id?: string
+          category?: string
+          description?: string | null
+          status?: string
+          created_at?: string | null
+          resolved_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "incidents_subject_id_fkey"
+            columns: ["subject_id"]
+            isOneToOne: false
+            referencedRelation: "subjects"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       log_entries: {
         Row: {
           created_at: string | null
@@ -1171,3 +1209,13 @@ export const Constants = {
     },
   },
 } as const
+
+export interface Incident {
+  id: string
+  subject_id: string
+  category: string
+  description: string | null
+  status: string
+  created_at: string | null
+  resolved_at: string | null
+}

--- a/src/pages/IncidentDetail.tsx
+++ b/src/pages/IncidentDetail.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import Layout from "@/components/Layout";
+import { useToast } from "@/hooks/use-toast";
+import { Clock } from "lucide-react";
+import { IncidentStatus } from "@/types/database";
+
+const IncidentDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const isNew = id === "new";
+  const subjectIdFromQuery = searchParams.get("subject_id") || "";
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [formData, setFormData] = useState({
+    subject_id: subjectIdFromQuery,
+    category: "",
+    description: "",
+    status: "open" as IncidentStatus,
+  });
+
+  const { data: incident, isLoading } = useQuery({
+    queryKey: ["incident", id],
+    queryFn: async () => {
+      if (isNew) return null;
+      const { data, error } = await supabase
+        .from("incidents")
+        .select("*")
+        .eq("id", id)
+        .single();
+      if (error) throw error;
+      return data;
+    },
+    enabled: !isNew,
+  });
+
+  useEffect(() => {
+    if (incident) {
+      setFormData({
+        subject_id: incident.subject_id,
+        category: incident.category,
+        description: incident.description || "",
+        status: incident.status as IncidentStatus,
+      });
+    }
+  }, [incident]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const payload: any = {
+        subject_id: formData.subject_id,
+        category: formData.category,
+        description: formData.description,
+        status: formData.status,
+        resolved_at: formData.status === "resolved" ? new Date().toISOString() : null,
+      };
+      if (isNew) {
+        const { error } = await supabase.from("incidents").insert(payload);
+        if (error) throw error;
+      } else {
+        const { error } = await supabase
+          .from("incidents")
+          .update(payload)
+          .eq("id", id);
+        if (error) throw error;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["incident", id] });
+      queryClient.invalidateQueries({ queryKey: ["incidents"] });
+      queryClient.invalidateQueries({ queryKey: ["subject-incidents", formData.subject_id] });
+      toast({
+        title: "Incidencia guardada",
+        description: `Estado actualizado a ${formData.status}`,
+      });
+      if (isNew && formData.subject_id) {
+        navigate(`/subjects/${formData.subject_id}`);
+      }
+    },
+    onError: () => {
+      toast({
+        title: "Error",
+        description: "No se pudo guardar la incidencia",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSave = () => {
+    mutation.mutate();
+  };
+
+  if (isLoading) {
+    return (
+      <Layout>
+        <div className="flex items-center justify-center py-8">
+          <Clock className="mr-2 h-4 w-4 animate-spin" /> Cargando incidencia...
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <Card className="max-w-xl mx-auto">
+        <CardHeader>
+          <CardTitle>{isNew ? "Nueva incidencia" : "Detalle de incidencia"}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <label className="text-sm font-medium">Categoría</label>
+            <Input
+              value={formData.category}
+              onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium">Descripción</label>
+            <Textarea
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium">Estado</label>
+            <Select
+              value={formData.status}
+              onValueChange={(value) =>
+                setFormData({ ...formData, status: value as IncidentStatus })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="open">Abierta</SelectItem>
+                <SelectItem value="in_progress">En Progreso</SelectItem>
+                <SelectItem value="resolved">Resuelta</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Button onClick={handleSave}>Guardar</Button>
+        </CardContent>
+      </Card>
+    </Layout>
+  );
+};
+
+export default IncidentDetail;
+

--- a/src/pages/IncidentsList.tsx
+++ b/src/pages/IncidentsList.tsx
@@ -1,0 +1,116 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
+import Layout from "@/components/Layout";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+import { Plus, AlertTriangle, Clock } from "lucide-react";
+
+const getStatusBadge = (status: string) => {
+  const variants: Record<string, { variant: any; label: string }> = {
+    open: { variant: "secondary", label: "Abierta" },
+    in_progress: { variant: "default", label: "En Progreso" },
+    resolved: { variant: "default", label: "Resuelta" },
+  };
+  const config = variants[status] || variants.open;
+  return <Badge variant={config.variant}>{config.label}</Badge>;
+};
+
+const IncidentsList = () => {
+  const { data: incidents, isLoading } = useQuery({
+    queryKey: ["incidents"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("incidents")
+        .select(
+          `id, subject_id, category, description, status, created_at, resolved_at, subjects ( id, title )`
+        )
+        .order("created_at", { ascending: false });
+      if (error) throw error;
+      return data;
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <Layout>
+        <div className="flex items-center justify-center py-8">
+          <Clock className="mr-2 h-4 w-4 animate-spin" /> Cargando incidencias...
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold">Incidencias</h1>
+            <p className="text-muted-foreground">Listado de incidencias registradas</p>
+          </div>
+          <Link to="/incidents/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" /> Nueva incidencia
+            </Button>
+          </Link>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center">
+              <AlertTriangle className="mr-2 h-4 w-4" /> Incidencias
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>OT</TableHead>
+                  <TableHead>Categoría</TableHead>
+                  <TableHead>Estado</TableHead>
+                  <TableHead>Creada</TableHead>
+                  <TableHead className="text-right">Acciones</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {!incidents || incidents.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+                      No hay incidencias registradas
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  incidents.map((inc: any) => (
+                    <TableRow key={inc.id}>
+                      <TableCell>{inc.subjects?.title || inc.subject_id}</TableCell>
+                      <TableCell>{inc.category}</TableCell>
+                      <TableCell>{getStatusBadge(inc.status)}</TableCell>
+                      <TableCell>
+                        {inc.created_at ? format(new Date(inc.created_at), "dd/MM/yyyy", { locale: es }) : "-"}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Link to={`/incidents/${inc.id}`}>
+                          <Button variant="outline" size="sm">
+                            Ver
+                          </Button>
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </Layout>
+  );
+};
+
+export default IncidentsList;
+

--- a/src/pages/SubjectDetail.tsx
+++ b/src/pages/SubjectDetail.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Calendar, Clock, FileText, Image, BarChart3, Download, Plus, FileDown } from "lucide-react";
+import { Calendar, Clock, FileText, Image, BarChart3, Download, Plus, FileDown, AlertTriangle } from "lucide-react";
 import { Link } from "react-router-dom";
 import Layout from "@/components/Layout";
 import { format } from "date-fns";
@@ -79,6 +79,20 @@ const SubjectDetail = () => {
     enabled: !!subject?.tasks
   });
 
+  // Fetch incidents for this subject
+  const { data: incidents } = useQuery({
+    queryKey: ['subject-incidents', id],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('incidents')
+        .select('*')
+        .eq('subject_id', id);
+      if (error) throw error;
+      return data;
+    },
+    enabled: !!id
+  });
+
   const getStatusBadge = (status: TaskStatus | SubjectStatus | string) => {
     const variants = {
       'draft': { variant: 'outline' as const, label: 'Borrador' },
@@ -88,7 +102,9 @@ const SubjectDetail = () => {
       'pending': { variant: 'secondary' as const, label: 'Pendiente' },
       'in_progress': { variant: 'default' as const, label: 'En Progreso' },
       'completed': { variant: 'default' as const, label: 'Completada' },
-      'blocked': { variant: 'destructive' as const, label: 'Bloqueada' }
+      'blocked': { variant: 'destructive' as const, label: 'Bloqueada' },
+      'open': { variant: 'secondary' as const, label: 'Abierta' },
+      'resolved': { variant: 'default' as const, label: 'Resuelta' }
     };
     
     const config = variants[status as keyof typeof variants] || variants.draft;
@@ -236,6 +252,7 @@ const SubjectDetail = () => {
           <TabsList>
             <TabsTrigger value="timeline">Timeline</TabsTrigger>
             <TabsTrigger value="tasks">Tasks</TabsTrigger>
+            <TabsTrigger value="incidents">Incidencias</TabsTrigger>
             <TabsTrigger value="evidence">Evidencias</TabsTrigger>
             <TabsTrigger value="kpis">KPIs</TabsTrigger>
           </TabsList>
@@ -346,6 +363,61 @@ const SubjectDetail = () => {
                               <Button variant="outline" size="sm">
                                 Ver Detalle
                               </Button>
+                            </Link>
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* Incidents Tab */}
+          <TabsContent value="incidents">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span className="flex items-center">
+                    <AlertTriangle className="mr-2 h-4 w-4" />
+                    Incidencias
+                  </span>
+                  <Link to={`/incidents/new?subject_id=${id}`}>
+                    <Button size="sm">
+                      <Plus className="mr-2 h-4 w-4" /> Nueva incidencia
+                    </Button>
+                  </Link>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Categoría</TableHead>
+                      <TableHead>Estado</TableHead>
+                      <TableHead>Creada</TableHead>
+                      <TableHead className="text-right">Acciones</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {!incidents || incidents.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={4} className="text-center py-8 text-muted-foreground">
+                          No hay incidencias registradas
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      incidents.map((inc: any) => (
+                        <TableRow key={inc.id}>
+                          <TableCell>{inc.category}</TableCell>
+                          <TableCell>{getStatusBadge(inc.status)}</TableCell>
+                          <TableCell>
+                            {inc.created_at ? format(new Date(inc.created_at), 'dd/MM/yyyy', { locale: es }) : '-'}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Link to={`/incidents/${inc.id}`}>
+                              <Button variant="outline" size="sm">Ver</Button>
                             </Link>
                           </TableCell>
                         </TableRow>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -68,3 +68,16 @@ export const castLogMetadata = (data: any): LogMetadata => {
   if (!data || typeof data !== 'object') return {};
   return data as LogMetadata;
 };
+
+// Incident types
+export type IncidentStatus = "open" | "in_progress" | "resolved";
+
+export interface Incident {
+  id: string;
+  subject_id: string;
+  category: string;
+  description?: string;
+  status: IncidentStatus;
+  created_at: string;
+  resolved_at?: string | null;
+}

--- a/supabase/migrations/20250830223000_98d6f0de-5a2a-4f80-8c24-b1f508c45f43.sql
+++ b/supabase/migrations/20250830223000_98d6f0de-5a2a-4f80-8c24-b1f508c45f43.sql
@@ -1,0 +1,10 @@
+-- Create incidents table
+CREATE TABLE public.incidents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  subject_id UUID NOT NULL REFERENCES public.subjects(id) ON DELETE CASCADE,
+  category TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL DEFAULT 'open',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at TIMESTAMPTZ
+);


### PR DESCRIPTION
## Summary
- add `incidents` table migration and types
- implement incidents list and detail pages
- show incidents within subject detail with creation button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b37fff11f4832ebd3dcc7426fcb25e