### PR TITLE
feat: add subject type for subjects

### DIFF
--- a/knowledge.md
+++ b/knowledge.md
@@ -3,6 +3,8 @@
 
 **Entities:** Tenant, User(role: owner|editor|viewer), Subject(OT/Project), Task, Evidence(kind: photo|pdf, checksum, lat/lon), LogEntry, ChecklistTemplate, ChecklistRun.
 
+**Subject types:** project | research | maintenance | health | education | personal.
+
 **Business rules (blocking close):**
 - min_photos (>=3), geotag_required(true), signature_required(true), checklist_id(optional).
 - On close: status='closed', closed_at=now(), log event 'status_change'.

--- a/src/components/SubjectForm.tsx
+++ b/src/components/SubjectForm.tsx
@@ -1,0 +1,105 @@
+import { useForm } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SubjectType } from "@/types/database";
+
+export interface SubjectFormValues {
+  title: string;
+  description?: string;
+  subject_type: SubjectType;
+}
+
+interface SubjectFormProps {
+  defaultValues?: Partial<SubjectFormValues>;
+  onSubmit: (values: SubjectFormValues) => void;
+}
+
+export const SubjectForm = ({ defaultValues, onSubmit }: SubjectFormProps) => {
+  const form = useForm<SubjectFormValues>({
+    defaultValues: {
+      title: "",
+      description: "",
+      subject_type: "project",
+      ...defaultValues,
+    },
+  });
+
+  const handleSubmit = form.handleSubmit(onSubmit);
+
+  return (
+    <Form {...form}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Título</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Descripción</FormLabel>
+              <FormControl>
+                <Textarea {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="subject_type"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Tipo</FormLabel>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecciona un tipo" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="project">Proyecto</SelectItem>
+                  <SelectItem value="research">Investigación</SelectItem>
+                  <SelectItem value="maintenance">Mantenimiento</SelectItem>
+                  <SelectItem value="health">Salud</SelectItem>
+                  <SelectItem value="education">Educación</SelectItem>
+                  <SelectItem value="personal">Personal</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Guardar</Button>
+      </form>
+    </Form>
+  );
+};
+
+export default SubjectForm;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -695,6 +695,7 @@ export type Database = {
           due_date: string | null
           id: string
           status: Database["public"]["Enums"]["subject_status"]
+          subject_type: Database["public"]["Enums"]["subject_type"]
           tenant_id: string
           title: string
           updated_at: string | null
@@ -709,6 +710,7 @@ export type Database = {
           due_date?: string | null
           id?: string
           status?: Database["public"]["Enums"]["subject_status"]
+          subject_type?: Database["public"]["Enums"]["subject_type"]
           tenant_id: string
           title: string
           updated_at?: string | null
@@ -723,6 +725,7 @@ export type Database = {
           due_date?: string | null
           id?: string
           status?: Database["public"]["Enums"]["subject_status"]
+          subject_type?: Database["public"]["Enums"]["subject_type"]
           tenant_id?: string
           title?: string
           updated_at?: string | null
@@ -1026,6 +1029,13 @@ export type Database = {
       ai_output_type: "normalized_log" | "ocr" | "risk" | "summary" | "tags"
       evidence_kind: "photo" | "pdf"
       subject_status: "draft" | "active" | "closed" | "cancelled"
+      subject_type:
+        | "project"
+        | "research"
+        | "maintenance"
+        | "health"
+        | "education"
+        | "personal"
       task_status: "pending" | "in_progress" | "completed" | "blocked"
       user_role: "owner" | "editor" | "viewer"
     }
@@ -1166,6 +1176,14 @@ export const Constants = {
       ai_output_type: ["normalized_log", "ocr", "risk", "summary", "tags"],
       evidence_kind: ["photo", "pdf"],
       subject_status: ["draft", "active", "closed", "cancelled"],
+      subject_type: [
+        "project",
+        "research",
+        "maintenance",
+        "health",
+        "education",
+        "personal",
+      ],
       task_status: ["pending", "in_progress", "completed", "blocked"],
       user_role: ["owner", "editor", "viewer"],
     },

--- a/src/pages/SubjectDetail.tsx
+++ b/src/pages/SubjectDetail.tsx
@@ -11,7 +11,7 @@ import { Link } from "react-router-dom";
 import Layout from "@/components/Layout";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
-import { TaskStatus, SubjectStatus, castAIFlags } from "@/types/database";
+import { TaskStatus, SubjectStatus, SubjectType, castAIFlags } from "@/types/database";
 import { useToast } from "@/hooks/use-toast";
 
 const SubjectDetail = () => {
@@ -93,6 +93,18 @@ const SubjectDetail = () => {
     
     const config = variants[status as keyof typeof variants] || variants.draft;
     return <Badge variant={config.variant}>{config.label}</Badge>;
+  };
+
+  const getTypeBadge = (type: SubjectType) => {
+    const labels: Record<SubjectType, string> = {
+      project: 'Proyecto',
+      research: 'Investigación',
+      maintenance: 'Mantenimiento',
+      health: 'Salud',
+      education: 'Educación',
+      personal: 'Personal'
+    };
+    return <Badge variant="outline">{labels[type]}</Badge>;
   };
 
   const getComplianceChips = (task: any) => {
@@ -200,6 +212,7 @@ const SubjectDetail = () => {
             <div className="flex items-center space-x-4 mb-2">
               <h1 className="text-3xl font-bold">{subject.title}</h1>
               {getStatusBadge(subject.status)}
+              {getTypeBadge(subject.subject_type)}
             </div>
             {subject.description && (
               <p className="text-muted-foreground">{subject.description}</p>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -45,6 +45,13 @@ export interface LogMetadata {
 // Task status types
 export type TaskStatus = "pending" | "in_progress" | "completed" | "blocked";
 export type SubjectStatus = "draft" | "active" | "closed" | "cancelled";
+export type SubjectType =
+  | "project"
+  | "research"
+  | "maintenance"
+  | "health"
+  | "education"
+  | "personal";
 export type UserRole = "owner" | "editor" | "viewer";
 export type EvidenceKind = "photo" | "pdf";
 

--- a/supabase/migrations/20250830223500_e712abb2-b8db-4a18-864a-5f8302a563cd.sql
+++ b/supabase/migrations/20250830223500_e712abb2-b8db-4a18-864a-5f8302a563cd.sql
@@ -1,0 +1,5 @@
+-- Add subject_type enum and column to subjects
+create type subject_type as enum ('project', 'research', 'maintenance', 'health', 'education', 'personal');
+
+alter table subjects
+  add column subject_type subject_type not null default 'project';


### PR DESCRIPTION
## Summary
- add `subject_type` enum and column with migration and supabase types
- expose new `SubjectType` across frontend components and pages
- document subject types in knowledge base

## Testing
- `npm run lint` (fails: Unexpected any in existing functions)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b37ffd20e0832e99542782a0f3c358