### PR TITLE
feat: add subject-type KPIs to dashboard

### DIFF
--- a/src/components/KpiCard.tsx
+++ b/src/components/KpiCard.tsx
@@ -1,0 +1,27 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ReactNode } from "react";
+
+interface KpiCardProps {
+  title: string;
+  value: string | number;
+  description?: string;
+  icon?: ReactNode;
+}
+
+const KpiCard = ({ title, value, description, icon }: KpiCardProps) => (
+  <Card>
+    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+      <CardTitle className="text-sm font-medium">{title}</CardTitle>
+      {icon}
+    </CardHeader>
+    <CardContent>
+      <div className="text-2xl font-bold">{value}</div>
+      {description && (
+        <p className="text-xs text-muted-foreground">{description}</p>
+      )}
+    </CardContent>
+  </Card>
+);
+
+export default KpiCard;
+


### PR DESCRIPTION
## Summary
- add reusable KPI card component
- group dashboard metrics by subject type and render sections per type

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any errors)


------
https://chatgpt.com/codex/tasks/task_e_68b38003a3c8832e8fd53a666fe97744