### PR TITLE
feat: add subject creation page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import SubjectsList from "./pages/SubjectsList";
 import SubjectDetail from "./pages/SubjectDetail";
 import TaskDetail from "./pages/TaskDetail";
 import NotFound from "./pages/NotFound";
+import SubjectCreate from "./pages/SubjectCreate";
 
 const queryClient = new QueryClient();
 
@@ -22,6 +23,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/subjects" element={<SubjectsList />} />
+          <Route path="/subjects/new" element={<SubjectCreate />} />
           <Route path="/subjects/:id" element={<SubjectDetail />} />
           <Route path="/tasks/:id" element={<TaskDetail />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/pages/SubjectCreate.tsx
+++ b/src/pages/SubjectCreate.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import Layout from "@/components/Layout";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+
+const SubjectCreate = () => {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const { error } = await supabase
+        .from("subjects")
+        .insert({
+          title,
+          description,
+          due_date: dueDate || null,
+          status: "draft",
+        });
+      if (error) throw error;
+      await queryClient.invalidateQueries({ queryKey: ["subjects"] });
+      navigate("/subjects");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast({
+        title: "Error",
+        description: message,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Layout>
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold">Nueva OT</h1>
+          <p className="text-muted-foreground">Crear una nueva orden de trabajo</p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="title" className="block text-sm font-medium mb-2">
+              Título
+            </label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="description" className="block text-sm font-medium mb-2">
+              Descripción
+            </label>
+            <Textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="dueDate" className="block text-sm font-medium mb-2">
+              Fecha de vencimiento
+            </label>
+            <Input
+              id="dueDate"
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+            />
+          </div>
+          <div className="flex justify-end space-x-2">
+            <Button type="button" variant="outline" onClick={() => navigate("/subjects")}>Cancelar</Button>
+            <Button type="submit">Crear</Button>
+          </div>
+        </form>
+      </div>
+    </Layout>
+  );
+};
+
+export default SubjectCreate;

--- a/src/pages/SubjectsList.tsx
+++ b/src/pages/SubjectsList.tsx
@@ -103,10 +103,12 @@ const SubjectsList = () => {
             <h1 className="text-3xl font-bold">Órdenes de Trabajo</h1>
             <p className="text-muted-foreground">Gestión de proyectos y OTs</p>
           </div>
-          <Button>
-            <Plus className="mr-2 h-4 w-4" />
-            Nueva OT
-          </Button>
+          <Link to="/subjects/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              Nueva OT
+            </Button>
+          </Link>
         </div>
 
         {/* Filters */}


### PR DESCRIPTION
## Summary
- add route and page to create new subject and return to list
- link subject list CTA to new subject page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68b3805f317c832e9afd7d9c45a237dd