### PR TITLE
feat: add task creation flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Dashboard from "./pages/Dashboard";
 import SubjectsList from "./pages/SubjectsList";
 import SubjectDetail from "./pages/SubjectDetail";
 import TaskDetail from "./pages/TaskDetail";
+import TaskCreate from "./pages/TaskCreate";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -23,6 +24,7 @@ const App = () => (
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/subjects" element={<SubjectsList />} />
           <Route path="/subjects/:id" element={<SubjectDetail />} />
+          <Route path="/tasks/new" element={<TaskCreate />} />
           <Route path="/tasks/:id" element={<TaskDetail />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />

--- a/src/pages/SubjectDetail.tsx
+++ b/src/pages/SubjectDetail.tsx
@@ -95,7 +95,7 @@ const SubjectDetail = () => {
     return <Badge variant={config.variant}>{config.label}</Badge>;
   };
 
-  const getComplianceChips = (task: any) => {
+  const getComplianceChips = (task: { ai_flags: unknown }) => {
     const flags = castAIFlags(task.ai_flags);
     const chips = [];
     
@@ -224,10 +224,12 @@ const SubjectDetail = () => {
               <Download className="mr-2 h-4 w-4" />
               Exportar PDF
             </Button>
-            <Button>
-              <Plus className="mr-2 h-4 w-4" />
-              Nueva Task
-            </Button>
+            <Link to={`/tasks/new?subjectId=${id}`}>
+              <Button>
+                <Plus className="mr-2 h-4 w-4" />
+                Nueva Task
+              </Button>
+            </Link>
           </div>
         </div>
 

--- a/src/pages/TaskCreate.tsx
+++ b/src/pages/TaskCreate.tsx
@@ -1,0 +1,98 @@
+import { useState, FormEvent } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import Layout from "@/components/Layout";
+import { useToast } from "@/hooks/use-toast";
+
+const TaskCreate = () => {
+  const [searchParams] = useSearchParams();
+  const subjectId = searchParams.get("subjectId");
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const [formData, setFormData] = useState({
+    title: "",
+    description: "",
+  });
+
+  const createTaskMutation = useMutation({
+    mutationFn: async () => {
+      if (!subjectId) throw new Error("Subject ID is required");
+      const { error } = await supabase.from("tasks").insert({
+        subject_id: subjectId,
+        title: formData.title,
+        description: formData.description,
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["subject", subjectId] });
+      toast({ title: "Task creada", description: "La task se creó correctamente." });
+      navigate(`/subjects/${subjectId}`);
+    },
+    onError: () => {
+      toast({ title: "Error", description: "No se pudo crear la task.", variant: "destructive" });
+    },
+  });
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    createTaskMutation.mutate();
+  };
+
+  if (!subjectId) {
+    return (
+      <Layout>
+        <div className="text-center py-8 text-muted-foreground">
+          Faltan parámetros para crear la task
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <form onSubmit={handleSubmit} className="max-w-2xl mx-auto">
+        <Card>
+          <CardHeader>
+            <CardTitle>Nueva Task</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="title" className="text-sm font-medium">
+                Título
+              </label>
+              <Input
+                id="title"
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="description" className="text-sm font-medium">
+                Descripción
+              </label>
+              <Textarea
+                id="description"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              />
+            </div>
+            <Button type="submit" disabled={createTaskMutation.isPending}>
+              Guardar
+            </Button>
+          </CardContent>
+        </Card>
+      </form>
+    </Layout>
+  );
+};
+
+export default TaskCreate;


### PR DESCRIPTION
## Summary
- link subject detail to task creation
- implement new task creation page and route
- redirect after saving and refresh subject tasks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / require import in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b38060e2ec832eaeef45f71c861aed