### PR TITLE
feat: add onboarding flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import SubjectsList from "./pages/SubjectsList";
 import SubjectDetail from "./pages/SubjectDetail";
 import TaskDetail from "./pages/TaskDetail";
 import NotFound from "./pages/NotFound";
+import Onboarding from "./pages/Onboarding";
 
 const queryClient = new QueryClient();
 
@@ -20,6 +21,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/onboarding" element={<Onboarding />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/subjects" element={<SubjectsList />} />
           <Route path="/subjects/:id" element={<SubjectDetail />} />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,15 +1,13 @@
 import { ReactNode } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { 
-  LayoutDashboard, 
-  FileText, 
-  CheckSquare, 
-  Settings, 
+import {
+  LayoutDashboard,
+  FileText,
+  CheckSquare,
   Menu,
-  Home
+  Home,
 } from "lucide-react";
 
 interface LayoutProps {
@@ -30,90 +28,90 @@ const Layout = ({ children }: LayoutProps) => {
     return location.pathname.startsWith(href);
   };
 
+  const hideNavigation = location.pathname.startsWith("/onboarding");
+
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-card">
-        <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-16">
-            {/* Logo */}
-            <Link to="/" className="flex items-center space-x-2">
-              <CheckSquare className="h-8 w-8 text-primary" />
-              <span className="text-xl font-bold">Bitácora</span>
-            </Link>
+      {!hideNavigation && (
+        <>
+          <header className="border-b bg-card">
+            <div className="container mx-auto px-4">
+              <div className="flex items-center justify-between h-16">
+                <Link to="/" className="flex items-center space-x-2">
+                  <CheckSquare className="h-8 w-8 text-primary" />
+                  <span className="text-xl font-bold">Bitácora</span>
+                </Link>
 
-            {/* Navigation */}
-            <nav className="hidden md:flex items-center space-x-4">
-              {navigation.map((item) => {
-                const Icon = item.icon;
-                return (
-                  <Link
-                    key={item.name}
-                    to={item.href}
-                    className={`flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                      isActive(item.href)
-                        ? "bg-primary text-primary-foreground"
-                        : "text-muted-foreground hover:text-foreground hover:bg-muted"
-                    }`}
-                  >
-                    <Icon className="h-4 w-4" />
-                    <span>{item.name}</span>
-                  </Link>
-                );
-              })}
-            </nav>
+                <nav className="hidden md:flex items-center space-x-4">
+                  {navigation.map((item) => {
+                    const Icon = item.icon;
+                    return (
+                      <Link
+                        key={item.name}
+                        to={item.href}
+                        className={`flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                          isActive(item.href)
+                            ? "bg-primary text-primary-foreground"
+                            : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                        }`}
+                      >
+                        <Icon className="h-4 w-4" />
+                        <span>{item.name}</span>
+                      </Link>
+                    );
+                  })}
+                </nav>
 
-            {/* User Menu */}
-            <div className="flex items-center space-x-2">
-              <Badge variant="outline">Demo</Badge>
-              <Button variant="ghost" size="icon" className="md:hidden">
-                <Menu className="h-4 w-4" />
-              </Button>
+                <div className="flex items-center space-x-2">
+                  <Badge variant="outline">Demo</Badge>
+                  <Button variant="ghost" size="icon" className="md:hidden">
+                    <Menu className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <div className="md:hidden border-b bg-card">
+            <div className="container mx-auto px-4">
+              <div className="flex space-x-2 py-2 overflow-x-auto">
+                {navigation.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <Link
+                      key={item.name}
+                      to={item.href}
+                      className={`flex items-center space-x-1 px-3 py-2 rounded-md text-xs font-medium whitespace-nowrap transition-colors ${
+                        isActive(item.href)
+                          ? "bg-primary text-primary-foreground"
+                          : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                      }`}
+                    >
+                      <Icon className="h-3 w-3" />
+                      <span>{item.name}</span>
+                    </Link>
+                  );
+                })}
+              </div>
             </div>
           </div>
-        </div>
-      </header>
+        </>
+      )}
 
-      {/* Mobile Navigation */}
-      <div className="md:hidden border-b bg-card">
-        <div className="container mx-auto px-4">
-          <div className="flex space-x-2 py-2 overflow-x-auto">
-            {navigation.map((item) => {
-              const Icon = item.icon;
-              return (
-                <Link
-                  key={item.name}
-                  to={item.href}
-                  className={`flex items-center space-x-1 px-3 py-2 rounded-md text-xs font-medium whitespace-nowrap transition-colors ${
-                    isActive(item.href)
-                      ? "bg-primary text-primary-foreground"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
-                  }`}
-                >
-                  <Icon className="h-3 w-3" />
-                  <span>{item.name}</span>
-                </Link>
-              );
-            })}
+      <main className="container mx-auto px-4 py-8">{children}</main>
+
+      {!hideNavigation && (
+        <footer className="border-t bg-card mt-auto">
+          <div className="container mx-auto px-4 py-6">
+            <div className="text-center text-sm text-muted-foreground">
+              <p>© 2024 Bitácora - Sistema de Gestión Operativa</p>
+            </div>
           </div>
-        </div>
-      </div>
-
-      {/* Main Content */}
-      <main className="container mx-auto px-4 py-8">
-        {children}
-      </main>
-
-      {/* Footer */}
-      <footer className="border-t bg-card mt-auto">
-        <div className="container mx-auto px-4 py-6">
-          <div className="text-center text-sm text-muted-foreground">
-            <p>© 2024 Bitácora - Sistema de Gestión Operativa</p>
-          </div>
-        </div>
-      </footer>
+        </footer>
+      )}
     </div>
   );
 };
 
 export default Layout;
+

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Layout from "@/components/Layout";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const Onboarding = () => {
+  const [step, setStep] = useState(0);
+  const [orgName, setOrgName] = useState("");
+  const [teamName, setTeamName] = useState("");
+  const [role, setRole] = useState("viewer");
+  const navigate = useNavigate();
+
+  const nextStep = () => setStep((s) => s + 1);
+
+  const finish = () => {
+    const redirects: Record<string, string> = {
+      owner: "/dashboard",
+      editor: "/subjects",
+      viewer: "/",
+    };
+    navigate(redirects[role] || "/");
+  };
+
+  return (
+    <Layout>
+      <Card className="max-w-md mx-auto">
+        <CardHeader>
+          <CardTitle>Onboarding</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {step === 0 && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="org">Nombre de la organización</Label>
+                <Input
+                  id="org"
+                  value={orgName}
+                  onChange={(e) => setOrgName(e.target.value)}
+                />
+              </div>
+              <Button onClick={nextStep}>Siguiente</Button>
+            </>
+          )}
+
+          {step === 1 && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="team">Nombre del equipo</Label>
+                <Input
+                  id="team"
+                  value={teamName}
+                  onChange={(e) => setTeamName(e.target.value)}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="role">Rol</Label>
+                <select
+                  id="role"
+                  value={role}
+                  onChange={(e) => setRole(e.target.value)}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                >
+                  <option value="owner">Administrador</option>
+                  <option value="editor">Miembro</option>
+                  <option value="viewer">Observador</option>
+                </select>
+              </div>
+
+              <Button onClick={finish}>Finalizar</Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </Layout>
+  );
+};
+
+export default Onboarding;
+


### PR DESCRIPTION
## Summary
- add onboarding page to configure organization and team
- register onboarding route and hide global navigation during setup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b380eef7f8832eab04367bc6c82716