### PR TITLE
Add role-based dashboards and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,10 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Index from "./pages/Index";
-import Dashboard from "./pages/Dashboard";
+import JefeDashboard from "./pages/JefeDashboard";
+import OperadorDashboard from "./pages/OperadorDashboard";
 import SubjectsList from "./pages/SubjectsList";
 import SubjectDetail from "./pages/SubjectDetail";
 import TaskDetail from "./pages/TaskDetail";
@@ -20,7 +21,21 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
-          <Route path="/dashboard" element={<Dashboard />} />
+          <Route
+            path="/dashboard"
+            element={
+              <Navigate
+                to={
+                  (localStorage.getItem('role') || 'operador') === 'jefe'
+                    ? '/dashboard/jefe'
+                    : '/dashboard/operador'
+                }
+                replace
+              />
+            }
+          />
+          <Route path="/dashboard/jefe" element={<JefeDashboard />} />
+          <Route path="/dashboard/operador" element={<OperadorDashboard />} />
           <Route path="/subjects" element={<SubjectsList />} />
           <Route path="/subjects/:id" element={<SubjectDetail />} />
           <Route path="/tasks/:id" element={<TaskDetail />} />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,13 +1,12 @@
 import { ReactNode } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { 
-  LayoutDashboard, 
-  FileText, 
-  CheckSquare, 
-  Settings, 
+import {
+  LayoutDashboard,
+  FileText,
+  CheckSquare,
+  Settings,
   Menu,
   Home
 } from "lucide-react";
@@ -19,11 +18,20 @@ interface LayoutProps {
 const Layout = ({ children }: LayoutProps) => {
   const location = useLocation();
 
-  const navigation = [
-    { name: "Inicio", href: "/", icon: Home },
-    { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
-    { name: "OTs", href: "/subjects", icon: FileText },
-  ];
+  const role = localStorage.getItem('role') || 'operador';
+  const navigation =
+    role === 'jefe'
+      ? [
+          { name: 'Inicio', href: '/', icon: Home },
+          { name: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
+          { name: 'OTs', href: '/subjects', icon: FileText },
+          { name: 'Admin', href: '/admin', icon: Settings },
+        ]
+      : [
+          { name: 'Inicio', href: '/', icon: Home },
+          { name: 'Mis Tareas', href: '/dashboard', icon: CheckSquare },
+          { name: 'OTs', href: '/subjects', icon: FileText },
+        ];
 
   const isActive = (href: string) => {
     if (href === "/") return location.pathname === "/";
@@ -65,7 +73,7 @@ const Layout = ({ children }: LayoutProps) => {
 
             {/* User Menu */}
             <div className="flex items-center space-x-2">
-              <Badge variant="outline">Demo</Badge>
+              <Badge variant="outline" className="capitalize">{role}</Badge>
               <Button variant="ghost" size="icon" className="md:hidden">
                 <Menu className="h-4 w-4" />
               </Button>

--- a/src/pages/JefeDashboard.tsx
+++ b/src/pages/JefeDashboard.tsx
@@ -9,9 +9,9 @@ import { Link } from "react-router-dom";
 import Layout from "@/components/Layout";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
-import { TaskStatus, castAIFlags } from "@/types/database";
+import { TaskStatus } from "@/types/database";
 
-const Dashboard = () => {
+const JefeDashboard = () => {
   // Fetch KPI data
   const { data: kpiData, isLoading: kpiLoading } = useQuery({
     queryKey: ['dashboard-kpis'],
@@ -80,9 +80,14 @@ const Dashboard = () => {
     return <Badge variant={config.variant}>{config.label}</Badge>;
   };
 
-  const getRiskLevel = (task: any) => {
-    const isOverdue = task.due_date && new Date(task.due_date) < new Date();
-    const hasHighRisk = task.ai_risk && task.ai_risk > 70;
+  interface RiskTask {
+    due_date?: string | null;
+    ai_risk?: number | null;
+  }
+
+  const getRiskLevel = (task: RiskTask) => {
+    const isOverdue = task.due_date ? new Date(task.due_date) < new Date() : false;
+    const hasHighRisk = task.ai_risk ? task.ai_risk > 70 : false;
     
     if (isOverdue) return { level: 'Vencida', color: 'text-destructive' };
     if (hasHighRisk) return { level: 'Alto Riesgo', color: 'text-orange-500' };
@@ -95,8 +100,8 @@ const Dashboard = () => {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold">Dashboard</h1>
-            <p className="text-muted-foreground">Resumen operativo y KPIs de cumplimiento</p>
+            <h1 className="text-3xl font-bold">Dashboard del Jefe</h1>
+            <p className="text-muted-foreground">Resumen operativo y administración</p>
           </div>
           <Link to="/subjects">
             <Button>
@@ -242,4 +247,4 @@ const Dashboard = () => {
   );
 };
 
-export default Dashboard;
+export default JefeDashboard;

--- a/src/pages/OperadorDashboard.tsx
+++ b/src/pages/OperadorDashboard.tsx
@@ -1,0 +1,97 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import Layout from "@/components/Layout";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { TaskStatus } from "@/types/database";
+import { Link } from "react-router-dom";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+import { Clock } from "lucide-react";
+
+const OperadorDashboard = () => {
+  const { data: tasks, isLoading } = useQuery({
+    queryKey: ['operador-tasks'],
+    queryFn: async () => {
+      const today = format(new Date(), 'yyyy-MM-dd');
+      const { data, error } = await supabase
+        .from('tasks')
+        .select(`id, title, status, due_date, subjects ( id, title )`)
+        .eq('due_date', today)
+        .neq('status', 'completed');
+      if (error) throw error;
+      return data;
+    }
+  });
+
+  const getStatusBadge = (status: TaskStatus | string) => {
+    const variants = {
+      'pending': { variant: 'secondary' as const, label: 'Pendiente' },
+      'in_progress': { variant: 'default' as const, label: 'En Progreso' },
+      'completed': { variant: 'default' as const, label: 'Completada' },
+      'blocked': { variant: 'destructive' as const, label: 'Bloqueada' }
+    };
+
+    const config = variants[status as keyof typeof variants] || variants.pending;
+    return <Badge variant={config.variant}>{config.label}</Badge>;
+  };
+
+  return (
+    <Layout>
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold">Tareas del Día</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>Mis Tareas</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <Clock className="mr-2 h-4 w-4 animate-spin" />
+                Cargando...
+              </div>
+            ) : tasks && tasks.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Task</TableHead>
+                    <TableHead>OT</TableHead>
+                    <TableHead>Vencimiento</TableHead>
+                    <TableHead>Estado</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {tasks.map((task) => (
+                    <TableRow key={task.id}>
+                      <TableCell className="font-medium">
+                        <Link to={`/tasks/${task.id}`} className="hover:underline">
+                          {task.title}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <Link to={`/subjects/${task.subjects.id}`} className="hover:underline text-primary">
+                          {task.subjects.title}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        {task.due_date ? format(new Date(task.due_date), 'dd/MM/yyyy', { locale: es }) : 'Sin fecha'}
+                      </TableCell>
+                      <TableCell>{getStatusBadge(task.status)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <div className="text-center py-8 text-muted-foreground">
+                No tienes tareas para hoy
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </Layout>
+  );
+};
+
+export default OperadorDashboard;


### PR DESCRIPTION
## Summary
- introduce separate dashboards for `jefe` and `operador` roles
- show navigation links based on stored user role
- redirect `/dashboard` to the appropriate dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors in existing files)*
- `npx eslint src/pages/JefeDashboard.tsx src/pages/OperadorDashboard.tsx src/components/Layout.tsx src/App.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b380f32a64832e9e0c6cfb82e0cc61