### PR TITLE
feat: paginate evidence with thumbnails

### DIFF
--- a/src/components/EvidenceUpload.tsx
+++ b/src/components/EvidenceUpload.tsx
@@ -8,6 +8,14 @@ import { Upload, X, AlertTriangle } from "lucide-react";
 import CryptoJS from "crypto-js";
 import { EvidenceKind } from "@/types/database";
 
+export const getEvidenceThumbnailUrl = (filePath: string) =>
+  supabase.storage
+    .from("bitacora")
+    .getPublicUrl(filePath, { transform: { width: 150 } }).data.publicUrl;
+
+export const getEvidencePublicUrl = (filePath: string) =>
+  supabase.storage.from("bitacora").getPublicUrl(filePath).data.publicUrl;
+
 interface EvidenceUploadProps {
   taskId: string;
   tenantId: string;


### PR DESCRIPTION
## Summary
- add helpers for evidence thumbnail and full-size URLs
- paginate evidence list with lazy loading and 150px thumbnails
- load originals only when previews are clicked

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Unexpected any / forbidden require import)


------
https://chatgpt.com/codex/tasks/task_e_68b382bda95c832eaf713bc3b5ec1141