### PR TITLE
Improve toast accessibility and focus handling

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -11,14 +11,16 @@ const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Viewport
-    ref={ref}
-    className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
-      className
-    )}
-    {...props}
-  />
+  <div role="status" aria-live="polite">
+    <ToastPrimitives.Viewport
+      ref={ref}
+      className={cn(
+        "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+        className
+      )}
+      {...props}
+    />
+  </div>
 ))
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
@@ -74,6 +76,7 @@ const ToastClose = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Close
     ref={ref}
+    aria-label="Dismiss"
     className={cn(
       "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -142,6 +142,11 @@ type Toast = Omit<ToasterToast, "id">
 function toast({ ...props }: Toast) {
   const id = genId()
 
+  const previouslyFocused =
+    typeof document !== "undefined"
+      ? (document.activeElement as HTMLElement | null)
+      : null
+
   const update = (props: ToasterToast) =>
     dispatch({
       type: "UPDATE_TOAST",
@@ -160,6 +165,12 @@ function toast({ ...props }: Toast) {
       },
     },
   })
+
+  // Ensure that triggering a toast does not steal focus from the currently
+  // focused element. Re-focus after the toast has been dispatched.
+  if (previouslyFocused) {
+    setTimeout(() => previouslyFocused.focus(), 0)
+  }
 
   return {
     id: id,


### PR DESCRIPTION
## Summary
- wrap toast viewport in a `role="status"` region with `aria-live="polite"`
- add keyboard-accessible dismiss buttons with labels
- restore focus to previously focused element after showing a toast

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and require import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b382c0adf4832e8d3d289a61feb78c