### PR TITLE
docs: add API request examples and fix external docs link

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -453,6 +453,10 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateSubjectRequest'
+            example:
+              title: "Site inspection"
+              description: "Initial site survey"
+              due_date: "2025-01-15T09:00:00Z"
       responses:
         '201':
           description: Subject created
@@ -466,6 +470,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      x-codeSamples:
+        - lang: curl
+          label: Create subject
+          source: |
+            curl -X POST https://eeprxrlmcbtywuuwnuex.supabase.co/functions/v1/api-v1/subjects \
+              -H "Authorization: Bearer <your_jwt>" \
+              -H "X-Api-Key: bta_test_123" \
+              -H "Idempotency-Key: 123e4567-e89b-12d3-a456-426614174000" \
+              -H "Content-Type: application/json" \
+              -d '{"title":"Site inspection","description":"Initial site survey","due_date":"2025-01-15T09:00:00Z"}'
 
   /subjects/{id}:
     get:
@@ -508,6 +522,16 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateTaskRequest'
+            example:
+              subject_id: "11111111-1111-1111-1111-111111111111"
+              title: "Replace filter"
+              description: "Replace air filter"
+              assignee_id: "22222222-2222-2222-2222-222222222222"
+              due_date: "2025-01-20T15:00:00Z"
+              required_evidence:
+                min_photos: 3
+                geotag_required: true
+                signature_required: true
       responses:
         '201':
           description: Task created
@@ -521,6 +545,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      x-codeSamples:
+        - lang: curl
+          label: Create task
+          source: |
+            curl -X POST https://eeprxrlmcbtywuuwnuex.supabase.co/functions/v1/api-v1/tasks \
+              -H "Authorization: Bearer <your_jwt>" \
+              -H "X-Api-Key: bta_test_123" \
+              -H "Idempotency-Key: 123e4567-e89b-12d3-a456-426614174000" \
+              -H "Content-Type: application/json" \
+              -d '{"subject_id":"11111111-1111-1111-1111-111111111111","title":"Replace filter","description":"Replace air filter","assignee_id":"22222222-2222-2222-2222-222222222222","due_date":"2025-01-20T15:00:00Z","required_evidence":{"min_photos":3,"geotag_required":true,"signature_required":true}}'
 
   /tasks/{id}:
     get:
@@ -583,29 +617,38 @@ paths:
                 $ref: '#/components/schemas/Error'
 
   /tasks/{id}/close:
-    post:
-      summary: Close task
-      description: Close a task with compliance validation
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        required: true
-        content:
-          application/json:
+      post:
+        summary: Close task
+        description: Close a task with compliance validation
+        parameters:
+          - name: id
+            in: path
+            required: true
             schema:
-              $ref: '#/components/schemas/CloseTaskRequest'
-      responses:
-        '200':
-          description: Task closed successfully
+              type: string
+              format: uuid
+          - name: Idempotency-Key
+            in: header
+            schema:
+              type: string
+            description: Optional idempotency key for safe retries
+        requestBody:
+          required: true
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Task'
+                $ref: '#/components/schemas/CloseTaskRequest'
+              example:
+                signature_ref: "sig_123"
+                lat: 40.7128
+                lon: -74.0060
+        responses:
+          '200':
+            description: Task closed successfully
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Task'
         '400':
           description: Compliance requirements not met
           content:
@@ -616,6 +659,16 @@ paths:
                 type: "https://bitacora.api/errors/compliance_violation"
                 title: "Compliance Requirements Not Met"
                 detail: "Minimum 3 photos required; Signature required for task closure"
+        x-codeSamples:
+          - lang: curl
+            label: Close task
+            source: |
+              curl -X POST https://eeprxrlmcbtywuuwnuex.supabase.co/functions/v1/api-v1/tasks/00000000-0000-0000-0000-000000000000/close \
+                -H "Authorization: Bearer <your_jwt>" \
+                -H "X-Api-Key: bta_test_123" \
+                -H "Idempotency-Key: 123e4567-e89b-12d3-a456-426614174000" \
+                -H "Content-Type: application/json" \
+                -d '{"signature_ref":"sig_123","lat":40.7128,"lon":-74.0060}'
 
   /tasks/{id}/report.pdf:
     get:
@@ -647,12 +700,24 @@ paths:
     post:
       summary: Get presigned upload URL
       description: Get presigned URL for uploading evidence files
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          schema:
+            type: string
+          description: Optional idempotency key for safe retries
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PresignedUploadRequest'
+            example:
+              subject_id: "11111111-1111-1111-1111-111111111111"
+              task_id: "33333333-3333-3333-3333-333333333333"
+              filename: "evidence.jpg"
+              content_type: "image/jpeg"
+              size: 123456
       responses:
         '200':
           description: Presigned URL generated
@@ -666,6 +731,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      x-codeSamples:
+        - lang: curl
+          label: Presign upload
+          source: |
+            curl -X POST https://eeprxrlmcbtywuuwnuex.supabase.co/functions/v1/api-v1/uploads/presign \
+              -H "Authorization: Bearer <your_jwt>" \
+              -H "X-Api-Key: bta_test_123" \
+              -H "Idempotency-Key: 123e4567-e89b-12d3-a456-426614174000" \
+              -H "Content-Type: application/json" \
+              -d '{"subject_id":"11111111-1111-1111-1111-111111111111","task_id":"33333333-3333-3333-3333-333333333333","filename":"evidence.jpg","content_type":"image/jpeg","size":123456}'
 
 webhooks:
   TaskClosed:
@@ -705,4 +780,4 @@ webhooks:
 
 externalDocs:
   description: Full API Documentation
-  url: https://docs.bitacora.example.com
+  url: https://docs.bitacora.plus


### PR DESCRIPTION
## Summary
- add cURL examples with auth and idempotency headers for key POST endpoints
- update externalDocs URL to official docs site

## Testing
- `npx @redocly/cli@latest lint openapi.yaml` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@redocly%2fcli)*

------
https://chatgpt.com/codex/tasks/task_e_68b382c27164832eab964c9493d85569