### PR TITLE
feat: hero section

### DIFF
--- a/src/components/hero/Hero.tsx
+++ b/src/components/hero/Hero.tsx
@@ -1,0 +1,32 @@
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { CheckSquare } from "lucide-react";
+
+const Hero = () => {
+  return (
+    <section className="flex-1 flex flex-col items-center justify-center text-center px-4 space-y-6">
+      <CheckSquare className="h-16 w-16 text-primary" />
+      <div className="space-y-2">
+        <h1 className="text-4xl font-bold">Bitácora</h1>
+        <p className="text-xl text-muted-foreground">
+          La forma sencilla de gestionar tus operaciones.
+        </p>
+      </div>
+      <div className="flex flex-col sm:flex-row gap-4">
+        <Link to="/jefe/login" className="w-full sm:w-auto">
+          <Button size="lg" className="w-full">
+            Soy Jefe
+          </Button>
+        </Link>
+        <Link to="/operador/login" className="w-full sm:w-auto">
+          <Button variant="outline" size="lg" className="w-full">
+            Soy Operador
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default Hero;
+

--- a/src/components/hero/index.ts
+++ b/src/components/hero/index.ts
@@ -1,0 +1,1 @@
+export { default as Hero } from "./Hero";

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,32 +1,11 @@
-import { Link } from "react-router-dom";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CheckSquare, LayoutDashboard, FileText } from "lucide-react";
+import { Hero } from "@/components/hero";
 
 const Index = () => {
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <section className="flex-1 flex flex-col items-center justify-center text-center px-4 space-y-6">
-        <CheckSquare className="h-16 w-16 text-primary" />
-        <div className="space-y-2">
-          <h1 className="text-4xl font-bold">Bitácora</h1>
-          <p className="text-xl text-muted-foreground">
-            La forma sencilla de gestionar tus operaciones.
-          </p>
-        </div>
-        <div className="flex flex-col sm:flex-row gap-4">
-          <Link to="/jefe/login" className="w-full sm:w-auto">
-            <Button size="lg" className="w-full">
-              Soy Jefe
-            </Button>
-          </Link>
-          <Link to="/operador/login" className="w-full sm:w-auto">
-            <Button variant="outline" size="lg" className="w-full">
-              Soy Operador
-            </Button>
-          </Link>
-        </div>
-      </section>
+      <Hero />
 
       <section className="py-12 bg-muted">
         <div className="max-w-4xl mx-auto px-4 text-center space-y-8">


### PR DESCRIPTION
## Summary
- create reusable Hero component with call-to-action links
- export Hero from new hero module
- render Hero on landing page instead of inline markup

## Testing
- `npm run lint` *(fails: Unexpected any in supabase functions, A `require()` style import is forbidden)*
- `npx eslint src/pages/Index.tsx src/components/hero/Hero.tsx src/components/hero/index.ts`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b39cb15788832e8f3524d1ff109829