### PR TITLE
chore: sitemap & robots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -13,4 +13,4 @@ Allow: /
 User-agent: *
 Allow: /
 
-Sitemap: https://<tu-dominio>/sitemap.xml
+Sitemap: https://bitacora.plus/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://<tu-dominio>/</loc></url>
-  <url><loc>https://<tu-dominio>/dashboard</loc></url>
-  <url><loc>https://<tu-dominio>/subjects</loc></url>
+  <url><loc>https://bitacora.plus/login</loc></url>
+  <url><loc>https://bitacora.plus/</loc></url>
+  <url><loc>https://bitacora.plus/dashboard</loc></url>
+  <url><loc>https://bitacora.plus/subjects</loc></url>
 </urlset>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -14,7 +14,7 @@ while ((match = routeRegex.exec(content)) !== null) {
   routes.push(route);
 }
 
-const domain = 'https://<tu-dominio>';
+const domain = process.env.SITE_URL ?? 'https://bitacora.plus';
 const urls = routes.map((r) => `${domain}${r}`);
 const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n` +
   `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +


### PR DESCRIPTION
## Summary
- add configurable domain to sitemap generator
- regenerate sitemap with production URLs
- update robots.txt to reference new sitemap location

## Testing
- `npm run build:sitemap`
- `npm run lint` (fails: Unexpected any)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b39cb31890832e8d4d23e03389273b