### PR TITLE
Handle empty and non-JSON responses in SDK client

### DIFF
--- a/sdk/bitacora.ts
+++ b/sdk/bitacora.ts
@@ -175,7 +175,23 @@ export class BitacoraClient {
       throw new Error(`${error.title}: ${error.detail}`);
     }
 
-    return response.json();
+    // Handle empty responses (e.g., 204 No Content)
+    const contentLength = response.headers.get('Content-Length');
+    if (response.status === 204 || contentLength === '0') {
+      return null as unknown as T;
+    }
+
+    const contentType = response.headers.get('Content-Type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+
+    if (contentType.startsWith('text/')) {
+      return response.text() as unknown as T;
+    }
+
+    // Unsupported content type
+    throw new Error(`Unsupported response type: ${contentType || 'unknown'}`);
   }
 
   // Subjects API


### PR DESCRIPTION
## Summary
- Avoid parsing body for empty responses
- Parse response based on Content-Type and error on unsupported types

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: @typescript-eslint/no-explicit-any and others)


------
https://chatgpt.com/codex/tasks/task_e_68b5c72632f4832ebe80370ad6519c8f